### PR TITLE
Version 5.1

### DIFF
--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -666,7 +666,9 @@ class ConsignmentController extends Controller
                 'creation' => Carbon::parse($inv->creation)->format('F d, Y'),
                 'status' => $inv->status,
                 'transaction_date' => Carbon::parse($inv->transaction_date)->format('F d, Y'),
-                'items' => $items_arr
+                'items' => $items_arr,
+                'qty' => collect($items_arr)->sum('opening_stock'),
+                'amount' => collect($items_arr)->sum('price')
             ];
         }
 

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -653,7 +653,7 @@ class ConsignmentController extends Controller
         $beginning_inv_items = DB::table('tabConsignment Beginning Inventory Item')->whereIn('parent', $ids)->get();
         $beginning_inventory_items = collect($beginning_inv_items)->groupBy('parent');
 
-        $product_sold_arr = DB::table('tabConsignment Product Sold')->where('qty', '>', 0)->whereIn('branch_warehouse', $warehouses)
+        $product_sold_arr = DB::table('tabConsignment Product Sold')->where('qty', '>', 0)->whereIn('branch_warehouse', $warehouses)->where('status', '!=', 'Cancelled')
             ->select('transaction_date', 'branch_warehouse', 'item_code', 'description', 'price', DB::raw('sum(qty) as qty'), DB::raw('sum(amount) as amount'))
             ->groupBy('transaction_date', 'branch_warehouse', 'item_code', 'description', 'price')
             ->get();

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -2068,13 +2068,6 @@ class ConsignmentController extends Controller
                 }
             }
 
-            $transfer_type = null;
-            if($ste->purpose == 'Material Transfer'){
-                $transfer_type = $ste->transfer_as == 'Store Transfer' ? 'Store Transfer' : 'For Return';
-            }else{
-                $transfer_type = 'Sales Return';
-            }
-
             $ste_arr[] = [
                 'name' => $ste->name,
                 'from_warehouse' => $ste->from_warehouse,
@@ -2083,7 +2076,7 @@ class ConsignmentController extends Controller
                 'items' => $items_arr,
                 'owner' => $ste->owner,
                 'docstatus' => $ste->docstatus,
-                'transfer_type' => $transfer_type,
+                'transfer_type' => $ste->transfer_as,
                 'date' => $ste->creation
             ];
         }

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -28,32 +28,8 @@
 									<div class="card-body p-0">
 										<form action="/beginning_inv_list" method="get">
 											<div class="row p-2">
-												<div class="col-12 col-lg-2 col-xl-2 offset-xl-3">
+												<div class="col-12 col-lg-4 col-xl-4">
 													<input type="text" class="form-control filters-font" name="search" value="{{ request('search') ? request('search') : null }}" placeholder="Search"/>
-												</div>
-												<div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
-													@php
-														$statuses = ['For Approval', 'Approved', 'Cancelled'];
-													@endphp
-													<select name="status" class="form-control filters-font">
-														<option value="" disabled {{ Auth::user()->user_group == 'Promodiser' && !request('status') ? 'selected' : null }}>Select a status</option>
-														<option value="All" {{ request('status') ? ( request('status') == 'All' ? 'selected' : null) : null }}>Select All</option>
-														@foreach ($statuses as $status)
-														@php
-															$selected = null;
-															if(request('status')){
-																if(request('status') == $status){
-																	$selected = 'selected';
-																}
-															}else{
-																if(Auth::user()->user_group == 'Consignment Supervisor'){
-																	$selected = $status == 'For Approval' ? 'selected' : null;
-																}
-															}
-														@endphp
-														<option value="{{ $status }}" {{ $selected }}>{{ $status }}</option>
-														@endforeach
-													</select>
 												</div>
 												<div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
 													<select name="store" class="form-control filters-font">

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -243,7 +243,7 @@
 																				<div class="modal-header bg-navy">
 																					<h6 id="exampleModalLabel">Cancel Beginning Inventory?</h6>
 																					<button type="button" class="close">
-																					<span aria-hidden="true" style="color: #fff" onclick="close_modal('cancel-{{ $inv['name'] }}-Modal')">&times;</span>
+																					<span aria-hidden="true" style="color: #fff" onclick="close_modal('#cancel-{{ $inv['name'] }}-Modal')">&times;</span>
 																					</button>
 																				</div>
 																				<div class="modal-body">
@@ -257,7 +257,7 @@
 																								<th class="text-center" style="width: 20%;">Qty</th>
 																								<th class="text-center" style="width: 20%;">Amount</th>
 																							</tr>
-																							@foreach($inv['sold'] as $item)
+																							@forelse($inv['sold'] as $item)
 																								<tr>
 																									<td class="p-0" colspan=3>
 																										<div class="p-0 row">
@@ -291,7 +291,13 @@
 																										</div>
 																									</td>
 																								</tr>
-																							@endforeach
+																							@empty
+																								<tr>
+																									<td class='text-center' colspan=3>
+																										No record(s) found.
+																									</td>
+																								</tr>
+																							@endforelse
 																						</table>
 																					</div>
 																				</div>

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -247,59 +247,59 @@
 																					</button>
 																				</div>
 																				<div class="modal-body">
-																					<div class="callout callout-danger text-justify">
-																						<i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
-																					</div>
-																					<div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
-																						<table class="table">
-																							<tr>
-																								<th class="text-center" style='width: 60%;'>Item</th>
-																								<th class="text-center" style="width: 20%;">Qty</th>
-																								<th class="text-center" style="width: 20%;">Amount</th>
-																							</tr>
-																							@forelse($inv['sold'] as $item)
+																					@if ($inv['sold'])
+																						<div class="callout callout-danger text-justify">
+																							<i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
+																						</div>
+																						<div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
+																							<table class="table">
 																								<tr>
-																									<td class="p-0" colspan=3>
-																										<div class="p-0 row">
-																											<div class="col-6">
-																												<div class="row">
-																													<div class="col-4">
-																														<picture>
-																															<source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
-																															<source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
-																															<img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
-																														</picture>
-																													</div>
-																													<div class="col-8" style="display: flex; justify-content: center; align-items: center;">
-																														<b>{{ $item['item_code'] }}</b>
+																									<th class="text-center" style='width: 60%;'>Item</th>
+																									<th class="text-center" style="width: 20%;">Qty</th>
+																									<th class="text-center" style="width: 20%;">Amount</th>
+																								</tr>
+																								@foreach($inv['sold'] as $item)
+																									<tr>
+																										<td class="p-0" colspan=3>
+																											<div class="p-0 row">
+																												<div class="col-6">
+																													<div class="row">
+																														<div class="col-4">
+																															<picture>
+																																<source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
+																																<source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
+																																<img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+																															</picture>
+																														</div>
+																														<div class="col-8" style="display: flex; justify-content: center; align-items: center;">
+																															<b>{{ $item['item_code'] }}</b>
+																														</div>
 																													</div>
 																												</div>
+																												<div class="col-3 pt-2">
+																													<b>{{ number_format($item['qty']) }}</b> <br>
+																													<small>{{ $item['uom'] }}</small>
+																												</div>
+																												<div class="col-3" style="display: flex; justify-content: center; align-items: center;">
+																													₱ {{ number_format($item['price'], 2) }}
+																												</div>
 																											</div>
-																											<div class="col-3 pt-2">
-																												<b>{{ number_format($item['qty']) }}</b> <br>
-																												<small>{{ $item['uom'] }}</small>
+																											<div class="text-justify item-description">
+																												{{ $item['description'] }}
 																											</div>
-																											<div class="col-3" style="display: flex; justify-content: center; align-items: center;">
-																												₱ {{ number_format($item['price'], 2) }}
+																											<div class="text-justify pt-1 pb-2">
+																												<b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
 																											</div>
-																										</div>
-																										<div class="text-justify item-description">
-																											{{ $item['description'] }}
-																										</div>
-																										<div class="text-justify pt-1 pb-2">
-																											<b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
-																										</div>
-																									</td>
-																								</tr>
-																							@empty
-																								<tr>
-																									<td class='text-center' colspan=3>
-																										No record(s) found.
-																									</td>
-																								</tr>
-																							@endforelse
-																						</table>
-																					</div>
+																										</td>
+																									</tr>
+																								@endforeach
+																							</table>
+																						</div>
+																					@else
+																						<div class="callout callout-danger text-justify">
+																							<i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records.
+																						</div>
+																					@endif
 																				</div>
 																				<div class="modal-footer">
 																					<a href="/cancel/approved_beginning_inv/{{ $inv['name'] }}" class="btn btn-primary w-100">Confirm</a>

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -94,7 +94,7 @@
 										}else if($inv['status'] == 'Approved'){
 											$badge = 'success';
 										}else if($inv['status'] == 'Cancelled'){
-											$badge = 'danger';
+											$badge = 'secondary';
 										}
 
 										$modal_form = Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval' ? '/approve_beginning_inv/'.$inv['name'] : '/stock_adjust/submit/'.$inv['name'];
@@ -238,7 +238,7 @@
 																		</tr>
 																		<tr class="d-xl-none">
 																			<td colspan="4" class="text-justify pt-0 pb-1 pl-1 pr-1" style="border-top: 0 !important;">
-																				<div class="w-100 item-description">{!! strip_tags($item['item_description']) !!}</div>
+																				<div class="w-100 item-description">{{ strip_tags($item['item_description']) }}</div>
 																			</td>
 																		</tr>
 																		@empty
@@ -251,8 +251,81 @@
 															</div>
 															{{-- Update button for approved records --}}
 															@if ($inv['status'] == 'Approved')
-															<div class="modal-footer" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
-																<button type="submit" class="btn btn-info w-100">Update</button>
+															<div class="modal-footer">
+																<div class="container-fluid" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
+																	<button type="submit" class="btn btn-info w-100">Update</button>
+																</div>
+																<div class="container-fluid">
+																	<button type="button" class="btn btn-secondary w-100" data-toggle="modal" data-target="#cancel-{{ $inv['name'] }}-Modal">
+																		Cancel
+																	</button>
+																	  
+																	  <!-- Modal -->
+																	<div class="modal fade" id="cancel-{{ $inv['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+																		<div class="modal-dialog" role="document">
+																			<div class="modal-content">
+																				<div class="modal-header bg-navy">
+																					<h6 id="exampleModalLabel">Cancel Beginning Inventory?</h6>
+																					<button type="button" class="close">
+																					<span aria-hidden="true" style="color: #fff" onclick="close_modal('cancel-{{ $inv['name'] }}-Modal')">&times;</span>
+																					</button>
+																				</div>
+																				<div class="modal-body">
+																					<div class="callout callout-danger text-justify">
+																						<i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
+																					</div>
+																					<div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
+																						<table class="table">
+																							<tr>
+																								<th class="text-center" style='width: 60%;'>Item</th>
+																								<th class="text-center" style="width: 20%;">Qty</th>
+																								<th class="text-center" style="width: 20%;">Amount</th>
+																							</tr>
+																							@foreach($inv['sold'] as $item)
+																								<tr>
+																									<td class="p-0" colspan=3>
+																										<div class="p-0 row">
+																											<div class="col-6">
+																												<div class="row">
+																													<div class="col-4">
+																														<picture>
+																															<source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
+																															<source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
+																															<img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+																														</picture>
+																													</div>
+																													<div class="col-8" style="display: flex; justify-content: center; align-items: center;">
+																														<b>{{ $item['item_code'] }}</b>
+																													</div>
+																												</div>
+																											</div>
+																											<div class="col-3 pt-2">
+																												<b>{{ number_format($item['qty']) }}</b> <br>
+																												<small>{{ $item['uom'] }}</small>
+																											</div>
+																											<div class="col-3" style="display: flex; justify-content: center; align-items: center;">
+																												₱ {{ number_format($item['price'], 2) }}
+																											</div>
+																										</div>
+																										<div class="text-justify item-description">
+																											{{ $item['description'] }}
+																										</div>
+																										<div class="text-justify pt-1 pb-2">
+																											<b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
+																										</div>
+																									</td>
+																								</tr>
+																							@endforeach
+																						</table>
+																					</div>
+																				</div>
+																				<div class="modal-footer">
+																					<a href="/cancel/approved_beginning_inv/{{ $inv['name'] }}" class="btn btn-primary w-100">Confirm</a>
+																				</div>
+																			</div>
+																		</div>
+																	</div>
+																</div>
 															</div>
 															@endif
 														</form>
@@ -302,6 +375,9 @@
             text-align: justify;
             padding: 10px;
         }
+		.modal{
+			background-color: rgba(0,0,0,0.4);
+		}
         @media (max-width: 575.98px) {
 			.mobile-first{
 				width: 50% !important;
@@ -390,7 +466,7 @@
                 $('#'+$(this).data('name')+'-stock-adjust-update-btn').slideDown();
             });
 
-            var showTotalChar = 150, showChar = "Show more", hideChar = "Show less";
+            var showTotalChar = 98, showChar = "Show more", hideChar = "Show less";
             $('.item-description').each(function() {
                 var content = $(this).text();
                 if (content.length > showTotalChar) {

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -78,7 +78,9 @@
 							<table class="table" style="font-size: 9pt;">
 								<thead>
 									<th class="p-1 text-center align-middle d-none d-lg-table-cell">Date</th>
-									<th class="p-1 text-center align-middle" style="width: 50%;">Store</th>
+									<th class="p-1 text-center align-middle mobile-first">Store</th>
+									<th class="p-1 text-center align-middle d-none d-lg-table-cell">Total items</th>
+									<th class="p-1 text-center align-middle d-none d-lg-table-cell">Amount</th>
 									<th class="p-1 text-center align-middle d-none d-lg-table-cell">Submitted by</th>
 									<th class="p-1 text-center align-middle d-none d-lg-table-cell">Status</th>
 									<th class="p-1 text-center align-middle last-row">Action</th>
@@ -104,7 +106,13 @@
 										<td class="p-2 text-left align-middle text-xl-center">
 											<span class="d-block">{{ $inv['branch'] }}</span>
 											<small>By: {{ $inv['owner'] }} - {{ $inv['transaction_date'] }}</small>
+											<div class="row p-0 d-lg-none">
+												<div class="col-4"><b>Qty: </b>{{ number_format($inv['qty']) }}</div>
+												<div class="col-8"><b>Amount: </b>₱ {{ number_format($inv['amount'], 2) }}</div>
+											</div>
 										</td>
+										<td class="p-2 text-center align-middle d-none d-lg-table-cell">{{ number_format($inv['qty']) }}</td>
+										<td class="p-2 text-center align-middle d-none d-lg-table-cell">₱ {{ number_format($inv['amount'], 2) }}</td>
 										<td class="p-2 text-center align-middle d-none d-lg-table-cell">{{ $inv['owner'] }}</td>
 										<td class="p-2 text-center align-middle d-none d-lg-table-cell">
 											<span class="badge badge-{{ $badge }}">{{ $inv['status'] }}</span>
@@ -282,8 +290,11 @@
             display: none;
         }
         .last-row{
-            width: 20% !important;
+            width: 15% !important;
         }
+		.mobile-first{
+			width: 35% !important;
+		}
         .filters-font{
             font-size: 13px !important;
         }
@@ -292,8 +303,11 @@
             padding: 10px;
         }
         @media (max-width: 575.98px) {
+			.mobile-first{
+				width: 50% !important;
+			}
             .last-row{
-                width: 35%;
+                width: 20%;
             }
             .filters-font{
                 font-size: 9pt;
@@ -305,8 +319,11 @@
             }
         }
         @media (max-width: 767.98px) {
+			.mobile-first{
+				width: 50% !important;
+			}
             .last-row{
-                width: 35%;
+                width: 20%;
             }
             .filters-font{
                 font-size: 9pt;
@@ -318,8 +335,11 @@
             }
         }
         @media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : portrait) {
+			.mobile-first{
+				width: 50% !important;
+			}
             .last-row{
-                width: 35%;
+                width: 20%;
             }
             .filters-font{
                 font-size: 9pt;

--- a/resources/views/consignment/inventory_audit_form.blade.php
+++ b/resources/views/consignment/inventory_audit_form.blade.php
@@ -9,9 +9,16 @@
         <div class="container">
             <div class="row pt-1">
                 <div class="col-md-12 p-0 m-0">
-                    <div class="card card-secondary card-outline">
-                        <div class="card-header text-center">
-                            <span id="branch-name" class="font-weight-bolder d-block" style="font-size: 11pt;">{{ $branch }}</span>
+                    <div class="card card-lightblue">
+                        <div class="card-header text-center p-1">
+                            <div class="d-flex flex-row align-items-center">
+                                <div class="p-0 col-2 text-left">
+                                    <a href="/inventory_audit" class="btn btn-secondary m-0" style="width: 60px;"><i class="fas fa-arrow-left"></i></a>
+                                </div>
+                                <div class="p-1 col-8">
+                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Inventory Audit Form</span>
+                                </div>
+                            </div>
                         </div>
                         <div class="card-body p-1">
                             @if(session()->has('success'))
@@ -24,7 +31,7 @@
                                 {!! session()->get('error') !!}
                             </div>
                             @endif
-                            <h6 class="font-weight-bold text-center m-1 text-uppercase" style="font-size: 10pt;">Inventory Audit Form</h6>
+                            <h6 class="font-weight-bold text-center m-1 text-uppercase" style="font-size: 10pt;">{{ $branch }}</h6>
                             <h5 class="text-center mt-1 font-weight-bolder font-responsive">{{ $duration }}</h5>
                             <form action="/submit_inventory_audit_form" method="POST" autocomplete="off">
                                 @csrf

--- a/resources/views/consignment/product_sold_form.blade.php
+++ b/resources/views/consignment/product_sold_form.blade.php
@@ -10,8 +10,15 @@
             <div class="row pt-1">
                 <div class="col-md-12 p-0 m-0">
                     <div class="card card-lightblue">
-                        <div class="card-header text-center p-2">
-                            <span id="branch-name" class="font-weight-bolder d-block" style="font-size: 11pt;">{{ $branch }}</span>
+                        <div class="card-header text-center p-1">
+                            <div class="d-flex flex-row align-items-center">
+                                <div class="p-0 col-2 text-left">
+                                    <a href="/view_calendar_menu/{{ $branch }}" class="btn btn-secondary m-0" style="width: 60px;"><i class="fas fa-arrow-left"></i></a>
+                                </div>
+                                <div class="p-1 col-8">
+                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Product Sold Entry</span>
+                                </div>
+                            </div>
                         </div>
                         <div class="card-body p-1">
                             @if(session()->has('success'))
@@ -24,7 +31,7 @@
                                 {!! session()->get('error') !!}
                             </div>
                             @endif
-                            <h6 class="font-weight-bold text-center m-1 text-uppercase" style="font-size: 10pt;">Product Sold Entry</h6>
+                            <span id="branch-name" class="font-weight-bolder d-block text-center" style="font-size: 11pt;">{{ $branch }}</span>
                             <h5 class="text-center mt-1 font-weight-bolder">{{ \Carbon\Carbon::parse($transaction_date)->format('F d, Y') }}</h5>
                             <form action="/submit_product_sold_form" method="POST" autocomplete="off">
                                 @csrf

--- a/resources/views/consignment/promodiser_damage_report_form.blade.php
+++ b/resources/views/consignment/promodiser_damage_report_form.blade.php
@@ -9,8 +9,8 @@
             <div class="container">
                 <div class="row pt-1">
                     <div class="col-md-12 p-0 m-0">
-                        <div class="card card-secondary card-outline">
-                            <div class="card-header text-center" id="report">
+                        <div class="card card-lightblue">
+                            <div class="card-header text-center p-2" id="report">
                                 @if(session()->has('success'))
                                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                                         {{ session()->get('success') }}
@@ -21,16 +21,16 @@
                                         {{ session()->get('error') }}
                                     </div>
                                 @endif
-                                <span class="font-responsive font-weight-bold text-uppercase d-inline-block">Damage Report</span>
-                                <h5 class="text-center mt-1 font-weight-bolder">{{ \Carbon\Carbon::now()->format('F d, Y') }}</h5>
+                                <span class="font-responsive font-weight-bold text-uppercase d-inline-block">Damaged Report Form</span>
                             </div>
                             <div class="card-body p-0">
+                                <h6 class="text-center mt-2 font-weight-bolder">{{ \Carbon\Carbon::now()->format('F d, Y') }}</h6>
                                 <form action="/promodiser/damage_report/submit" method="post">
                                     @csrf
                                     <div class="container">
                                         <div class="row pt-2 pb-2">
                                             <div class="col-8">
-                                                <select name="branch" id="branch" class="form-control">
+                                                <select name="branch" id="branch" class="form-control form-control-sm">
                                                     <option value="" disabled selected>Select a Branch</option>
                                                     @foreach ($assigned_consignment_store as $store)
                                                         <option value="{{ $store }}" {{ !isset($beginning_inventory[$store]) ? 'disabled' : null }}>{{ $store }}</option>
@@ -38,7 +38,7 @@
                                                 </select>
                                             </div>
                                             <div class="col-4">
-                                                <button type="button" class="btn btn-outline-primary p-2" data-toggle="modal" id='add-modal-btn' data-target="#add-Modal" style='font-size: 10pt;' disabled>
+                                                <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" id='add-modal-btn' data-target="#add-Modal" disabled>
                                                     <i class="fa fa-plus"></i> Add Item
                                                 </button>
 
@@ -46,13 +46,14 @@
                                                 <div class="modal fade" id="add-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                                                     <div class="modal-dialog" role="document">
                                                         <div class="modal-content">
-                                                            <div class="modal-header">
+                                                            <div class="modal-header bg-navy">
                                                                 <h5 class="modal-title" id="exampleModalLabel">Select an Item</h5>
                                                                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                                                     <span aria-hidden="true">&times;</span>
                                                                 </button>
                                                             </div>
                                                             <div class="modal-body">
+                                                                <form></form>
                                                                 <select id="item-selection" class="form-control"></select>
 
                                                                 <table class="table table-striped d-none" id="item-selection-table">
@@ -118,9 +119,9 @@
                                             </div>
                                         </div>
                                         <div class="row">
-                                            <table class="table table-striped" id="selected-items-table">
+                                            <table class="table table-striped" id="selected-items-table" style="font-size: 9pt;">
                                                 <thead>
-                                                    <th class="font-responsive text-center p-1 align-middle" style="width: 42%">Item Code</th>
+                                                    <th class="font-responsive text-center p-1 align-middle">Item Code</th>
                                                     <th class="font-responsive text-center p-1 align-middle">Opening Stock</th>
                                                     <th class="font-responsive text-center p-1 align-middle">Price</th>
                                                 </thead>

--- a/resources/views/consignment/promodiser_damaged_list.blade.php
+++ b/resources/views/consignment/promodiser_damaged_list.blade.php
@@ -9,7 +9,7 @@
             <div class="container">
                 <div class="row pt-1">
                     <div class="col-md-12 p-0 m-0">
-                        <div class="card card-secondary card-outline">
+                        <div class="card card-lightblue">
                             @if(session()->has('success'))
                                 <div class="p-2">
                                     <div class="alert alert-success fade show font-responsive text-center" role="alert">
@@ -24,7 +24,7 @@
                                     </div>
                                 </div>
                             @endif
-                            <div class="card-header text-center">
+                            <div class="card-header text-center p-2">
                                 <span class="font-responsive font-weight-bold text-uppercase d-inline-block">Damaged Items List</span>
                             </div>
                             <div class="card-body p-0">
@@ -32,87 +32,77 @@
                                     <input type="text" class="form-control mt-2 mb-2" id="item-search" name="search" placeholder="Search" style="font-size: 9pt"/>
                                 </div>
                                <table class="table" id="items-table" style="font-size: 9.5pt">
-                                    <tr>
-                                        <th class="text-center" style="width: 75%">Item</th>
-                                        <th class="text-center" style="width: 25%">Action</th>
-                                    </tr>
+                                    <thead class="border-top">
+                                        <th class="text-center p-1 align-middle" style="width: 75%">Item Code</th>
+                                        <th class="text-center p-1 align-middle" style="width: 25%">Action</th>
+                                    </thead>
                                     @forelse ($damaged_arr as $i => $item)
                                         <tr>
-                                            <td class="text-center p-2" style="width: 75%">
-                                                <div class="row">
-                                                    <div class="col-3">
-                                                        <picture>
-                                                            <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp">
-                                                            <source srcset="{{ asset('storage/'.$item['image']) }}" type="image/jpeg">
-                                                            <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" class="img-thumbnail" width="100%">
-                                                        </picture>
+                                            <td class="text-center p-1 align-middle" style="width: 75%">
+                                                <div class="d-none"><!-- For Search -->
+                                                    {{ $item['store'] }} <br>
+                                                    {{ $item['damage_description'] }} <br>
+                                                    {{ $item['promodiser'] }} <br>
+                                                    {{ Carbon\Carbon::parse($item['creation'])->format('F d, Y') }}
+                                                </div>
+                                                <div class="d-flex flex-row align-items-center">
+                                                    <div class="p-1 text-center">
+                                                        <a href="{{ asset('storage/') }}{{ $item['image'] }}" data-toggle="mobile-lightbox" data-gallery="{{ $item['item_code'] }}" data-title="{{ $item['item_code'] }}">
+                                                            <picture>
+                                                                <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp" width="40" height="40">
+                                                                <source srcset="{{ asset('storage/'.$item['image']) }}" type="image/jpeg" width="40" height="40">
+                                                                <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+                                                            </picture>
+                                                        </a>
                                                     </div>
-                                                    <div class="col-9 text-left p-1">
-                                                        <b>{{ $item['item_code'] }}</b> <span class="badge badge-{{ $item['status'] == 'Returned' ? 'success' : 'primary' }}">{{ $item['status'] == 'Returned' ? $item['status'] : 'For Return' }}</span>
-                                                        <div class="col-12 text-justify p-0">
-                                                            {{ $item['store'] }} <br>
-                                                            <b>Reason: </b> {{ $item['damage_description'] }} <br>
-                                                            <b>Qty: </b> {{ number_format($item['damaged_qty']) }} <small style="white-space: nowrap">{{ $item['uom'] }}</small>
-                                                        </div>
-                                                    </div>
-                                                    <div class="d-none"><!-- For Search -->
-                                                        {{ $item['store'] }} <br>
-                                                        {{ $item['damage_description'] }} <br>
-                                                        {{ $item['promodiser'] }} <br>
-                                                        {{ Carbon\Carbon::parse($item['creation'])->format('F d, Y') }}
+                                                    <div class="p-1 m-0">
+                                                        <span class="font-weight-bold">{{ $item['item_code'] }}</span>
+                                                        <span class="badge badge-{{ $item['status'] == 'Returned' ? 'success' : 'primary' }}">{{ $item['status'] == 'Returned' ? $item['status'] : 'For Return' }}</span>
                                                     </div>
                                                 </div>
                                             </td>
-                                            <td class="text-center" style="width: 25%">
-                                                <a href='#' data-toggle="modal" data-target="#view-item-details-{{ $i }}-Modal">
-                                                    View
-                                                </a>
+                                            <td class="text-center p-1 align-middle" style="width: 25%">
+                                                <a href='#' data-toggle="modal" data-target="#view-item-details-{{ $i }}-Modal">View</a>
                                                   
                                                 <!-- Modal -->
                                                 <div class="modal fade" id="view-item-details-{{ $i }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                                                    <div class="modal-dialog" role="document">
+                                                    <div class="modal-dialog modal-dialog-centered" role="document">
                                                         <div class="modal-content">
-                                                            <div class="modal-header" style="background-color: #001F3F; color: #fff;">
-                                                                <div class="row text-left">
-                                                                    <div class="col-12">
-                                                                        <h5>Damaged Items</h5>
-                                                                    </div>
-                                                                    <div class="col-12">
-                                                                        <h6 id="exampleModalLabel">{{ $item['store'] }} <span class="badge badge-{{ $item['status'] == 'Returned' ? 'success' : 'primary' }}">{{ $item['status'] == 'Returned' ? $item['status'] : 'For Return' }}</span></h6>
-                                                                    </div>
-                                                                    <div class="col-12">
-                                                                        <span class="font-italic">{{ $item['promodiser'].' - '.Carbon\Carbon::parse($item['creation'])->format('F d, Y') }}</span>
-                                                                    </div>
-                                                                </div>
-                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                                <span aria-hidden="true" style="color: #fff;">&times;</span>
+                                                            <div class="modal-header bg-navy">
+                                                                <h6 class="modal-title"><b>Damaged Items</b>&nbsp;<span class="badge badge-{{ $item['status'] == 'Returned' ? 'success' : 'primary' }}">{{ $item['status'] == 'Returned' ? $item['status'] : 'For Return' }}</span></h6>
+                                                                <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
+                                                                    <span aria-hidden="true">&times;</span>
                                                                 </button>
                                                             </div>
                                                             <div class="modal-body">
-                                                                <div class="callout callout-info text-center">
+                                                                <h6 class="text-left m-0 p-0">{{ $item['store'] }}</h6>
+                                                                <small class="d-block text-left">{{ $item['promodiser'].' - '.Carbon\Carbon::parse($item['creation'])->format('F d, Y') }}</small>
+                                                                <div class="callout callout-info text-center mt-2">
                                                                     <small><i class="fas fa-info-circle"></i> Consignment Supervisor will notify that there are damaged/defective item in your store.</small>
                                                                 </div>
                                                                 <table class="table">
+                                                                    <thead>
+                                                                        <th class="p-1 align-middle text-center" style="width: 65% !important;">Item Code</th>
+                                                                        <th class="p-1 align-middle text-center">Qty</th>
+                                                                    </thead>
                                                                     <tr>
-                                                                        <th style="width: 65% !important">Item</th>
-                                                                        <th>Qty</th>
-                                                                    </tr>
-                                                                    <tr>
-                                                                        <td class="p-0">
-                                                                            <div class="row">
-                                                                                <div class="col-4">
-                                                                                    <picture>
-                                                                                        <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp">
-                                                                                        <source srcset="{{ asset('storage/'.$item['image']) }}" type="image/jpeg">
-                                                                                        <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" class="img-thumbnail" width="100%">
-                                                                                    </picture>
+                                                                        <td class="p-1 text-left align-middle">
+                                                                            <div class="d-flex flex-row align-items-center">
+                                                                                <div class="p-1 text-center">
+                                                                                    <a href="{{ asset('storage/') }}{{ $item['image'] }}" data-toggle="mobile-lightbox" data-gallery="{{ $item['item_code'] }}" data-title="{{ $item['item_code'] }}">
+                                                                                        <picture>
+                                                                                            <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp" width="40" height="40">
+                                                                                            <source srcset="{{ asset('storage/'.$item['image']) }}" type="image/jpeg" width="40" height="40">
+                                                                                            <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+                                                                                        </picture>
+                                                                                    </a>
                                                                                 </div>
-                                                                                <div class="col-4" style="display: flex; justify-content: center; align-items: center;">
-                                                                                    <b>{{ $item['item_code'] }}</b>
+                                                                                <div class="p-1 m-0">
+                                                                                    <span class="font-weight-bold">{{ $item['item_code'] }}</span>
                                                                                 </div>
                                                                             </div>
                                                                         </td>
-                                                                        <td>
+                                                                        <td class="p-1 align-middle text-center">
                                                                             <div class="container" style="display: flex; justify-content: center; align-items: center;">
                                                                                 <div>
                                                                                     <b>{{ number_format($item['damaged_qty']) }}</b> <br>
@@ -122,13 +112,9 @@
                                                                         </td>
                                                                     </tr>
                                                                     <tr>
-                                                                        <td colspan=2 class="text-justify p-0">
-                                                                            <div class="p-2 item-description container-fluid text-justify">
-                                                                                {{ strip_tags($item['item_description']) }} <br>
-                                                                            </div>
-                                                                            <div class='p-2'>
-                                                                                <b>Reason: </b> {{ $item['damage_description'] }} <br>
-                                                                            </div>
+                                                                        <td colspan="2" class="text-justify p-1 align-middle" style="border-top: 0 !important;">
+                                                                            <p>{!! strip_tags($item['item_description']) !!}</p>
+                                                                            <p class="mt-1"><b>Reason: </b> {{ $item['damage_description'] }}</p>
                                                                         </td>
                                                                     </tr>
                                                                 </table>
@@ -164,20 +150,19 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td colspan=2 class="p-0">
+                                            <td colspan="2" style="border-top: 0 !important;" class="pt-0 pb-2 pl-2 prl-2">
                                                 <div class="d-none"><!-- For Search -->
                                                     {{ $item['item_code'] }}
                                                 </div>
-                                                <div class="p-2 item-description container-fluid text-justify">
-                                                    {{ strip_tags($item['item_description']) }} <br>
-                                                </div>
+                                                <div class="item-description">{!! strip_tags($item['item_description']) !!}</div>
+                                                <span class="d-block mt-1 font-weight-bold">{{ $item['store'] }}</span>
+                                                <b>Reason: </b> {{ $item['damage_description'] }} <br>
+                                                <b>Qty: </b> {{ number_format($item['damaged_qty']) }} <small style="white-space: nowrap">{{ $item['uom'] }}</small>
                                             </td>
                                         </tr>
                                     @empty
                                         <tr>
-                                            <td colspan=2 class='text-center'>
-                                                No damaged item(s) reported.
-                                            </td>
+                                            <td colspan="2" class="text-uppercase text-muted text-center p-1 align-middle">No damaged item(s) reported</td>
                                         </tr>
                                     @endforelse
                                </table>
@@ -213,7 +198,7 @@
 
 @section('script')
     <script>
-        var showTotalChar = 120, showChar = "Show more", hideChar = "Show less";
+        var showTotalChar = 85, showChar = "Show more", hideChar = "Show less";
         $('.item-description').each(function() {
             var content = $(this).text();
             if (content.length > showTotalChar) {

--- a/resources/views/consignment/promodiser_delivery_report.blade.php
+++ b/resources/views/consignment/promodiser_delivery_report.blade.php
@@ -9,19 +9,15 @@
         <div class="container">
             <div class="row pt-1">
                 <div class="col-md-12 p-0 m-0">
-                    <div class="card card-secondary card-outline">
-                        <div class="card-header text-center">
+                    <div class="card card-lightblue">
+                        <div class="card-header text-center p-2">
                             @if(session()->has('success'))
-                                <div class="alert alert-success fade show font-responsive" role="alert">
-                                    {{ session()->get('success') }}
-                                </div>
+                            <div class="alert alert-success fade show font-responsive" role="alert">{{ session()->get('success') }}</div>
                             @endif
                             @if(session()->has('error'))
-                                <div class="alert alert-danger fade show font-responsive" role="alert">
-                                    {{ session()->get('error') }}
-                                </div>
+                            <div class="alert alert-danger fade show font-responsive" role="alert">{{ session()->get('error') }}</div>
                             @endif
-                            <span class="font-responsive font-weight-bold text-uppercase d-inline-block">
+                            <span class="font-weight-bolder d-block text-uppercase" style="font-size: 11pt;">
                                 @if ($type == 'all')
                                     Delivery Report
                                 @else
@@ -30,116 +26,150 @@
                             </span>
                         </div>
                         <div class="card-body p-1">
-                            <span class="float-right mr-3" style="font-size: 10pt">Total items: {{ $delivery_report->total() }}</span>
-                            <table class="table table-striped" style='font-size: 10pt;'>
-                                <tr>
-                                    <th class="text-center" style='width: 30%'>Name</th>
-                                    <th class="text-center">Store</th>
-                                </tr>
-                                @forelse ($ste_arr as $ste)
+                            <table class="table" style='font-size: 10pt;'>
+                                <thead>
+                                    <th class="text-center p-1 align-middle">Store</th>
+                                </thead>
+                                <tbody>
+                                    @forelse ($ste_arr as $ste)
                                     <tr>
-                                        <td class="text-center">
-                                            {{ $ste['name'] }}
-                                            <span class="badge badge-{{ $ste['status'] == 'Pending' ? 'warning' : 'success' }}">{{ $ste['status'] }}</span>
-                                        </td>
-                                        <td>
+                                        <td class="text-left p-1 align-middle">
                                             <a href="#" data-toggle="modal" data-target="#{{ $ste['name'] }}-Modal">{{ $ste['to_consignment'] }}</a>
+                                            <small class="d-block"><b>Delivery Date:</b> {{ Carbon\Carbon::parse($ste['delivery_date'])->format('F d, Y') }}</small>
+
+                                            <span class="badge badge-{{ $ste['status'] == 'Pending' ? 'warning' : 'success' }}">{{ $ste['status'] }}</span>
                                             @if ($ste['status'] == 'Delivered')
                                                 <span class="badge badge-{{ $ste['delivery_status'] == 0 ? 'warning' : 'success' }}">{{ $ste['delivery_status'] == 0 ? 'To Receive' : 'Received' }}</span>
                                             @endif
-                                            <br>
-                                            <span><b>Delivery Date:</b> {{ Carbon\Carbon::parse($ste['delivery_date'])->format('F d, Y') }}</span>
-
+                                           
                                             <div class="modal fade" id="{{ $ste['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                                                <div class="modal-dialog" role="document">
+                                                <div class="modal-dialog modal-dialog-centered" role="document">
                                                     <div class="modal-content">
-                                                        <div class="modal-header" style="background-color: #001F3F; color: #fff">
-                                                            <div class="row w-100">
-                                                                <div class="col-12">
-                                                                    <span>Delivered Items</span> <br>
-                                                                    <span>{{ $ste['to_consignment'] }}</span><br>
-                                                                    <span>{{ Carbon\Carbon::parse($ste['delivery_date'])->format('F d, Y') }}</span>
-                                                                </div>
-                                                            </div>
-                                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                                <span aria-hidden="true" style="color: #fff">&times;</span>
+                                                        <div class="modal-header bg-navy">
+                                                            <h6 class="modal-title">Delivered Item(s)</h6>
+                                                            <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
+                                                                <span aria-hidden="true">&times;</span>
                                                             </button>
                                                         </div>
                                                         <div class="modal-body">
+                                                            <form></form>
+                                                            <h5 class="text-center font-responsive font-weight-bold m-0">{{ $ste['to_consignment'] }}</h5>
+                                                            <small class="d-block text-center mb-2">Delivery Date: {{ Carbon\Carbon::parse($ste['delivery_date'])->format('F d, Y') }}</small>
                                                             <div class="callout callout-info text-center">
                                                                 <small><i class="fas fa-info-circle"></i> Once items are received, stocks will be automatically added to your current inventory.</small>
                                                             </div>
-                                                            <table class="table table-bordered">
-                                                                <tr>
-                                                                    <th class="text-center" style="width: 50%">Item</th>
-                                                                    <th class="text-center"><span style="white-space: nowrap">Delivered</span> Qty</th>
-                                                                    <th class="text-center">Price</th>
-                                                                </tr>
-                                                                @foreach ($ste['items'] as $item)
+                                                            <table class="table" style="font-size: 9pt;">
+                                                                <thead>
+                                                                    <th class="text-center p-1 align-middle" style="width: 40%">Item Code</th>
+                                                                    <th class="text-center p-1 align-middle" style="width: 30%">Delivered Qty</th>
+                                                                    <th class="text-center p-1 align-middle" style="width: 30%">Amount</th>
+                                                                </thead>
+                                                                <tbody>
+                                                                    @foreach ($ste['items'] as $item)
                                                                     @php
                                                                         $id = $ste['name'].'-'.$item['item_code'];
-
                                                                         $img = $item['image'] ? "/img/" . $item['image'] : "/icon/no_img.png";
                                                                         $img_webp = $item['image'] ? "/img/" . explode('.', $item['image'])[0].'.webp' : "/icon/no_img.webp";
                                                                     @endphp
                                                                     <tr>
-                                                                        <td colspan=3>
-                                                                            <div class="row">
-                                                                                <div class="col-6">
-                                                                                    <div class="row">
-                                                                                        <div class="col-6">
-                                                                                            <picture>
-                                                                                                <source srcset="{{ asset('storage'.$img_webp) }}" type="image/webp">
-                                                                                                <source srcset="{{ asset('storage'.$img) }}" type="image/jpeg">
-                                                                                                <img src="{{ asset('storage'.$img) }}" alt="{{ str_slug(explode('.', $img)[0], '-') }}" class="img-thumbna1il" width="100%">
-                                                                                            </picture>
+                                                                        <td class="text-left p-1 align-middle" style="border-bottom: 0 !important;">
+                                                                            <div class="d-flex flex-row justify-content-start align-items-center">
+                                                                                <div class="p-1 text-left">
+                                                                                    <a href="{{ asset('storage/') }}{{ $img }}" data-toggle="mobile-lightbox" data-gallery="{{ $item['item_code'] }}" data-title="{{ $item['item_code'] }}">
+                                                                                        <picture>
+                                                                                            <source srcset="{{ asset('storage'.$img_webp) }}" type="image/webp" alt="{{ str_slug(explode('.', $img)[0], '-') }}" width="40" height="40">
+                                                                                            <source srcset="{{ asset('storage'.$img) }}" type="image/jpeg" alt="{{ str_slug(explode('.', $img)[0], '-') }}" width="40" height="40">
+                                                                                            <img src="{{ asset('storage'.$img) }}" alt="{{ str_slug(explode('.', $img)[0], '-') }}" width="40" height="40">
+                                                                                        </picture>
+                                                                                    </a>
+                                                                                </div>
+                                                                                <div class="p-1 m-0">
+                                                                                    <span class="font-weight-bold">{{ $item['item_code'] }}</span>
+                                                                                </div>
+                                                                            </div>
+
+                                                                            <div class="modal fade" id="mobile-{{ $item['item_code'] }}-images-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                                                <div class="modal-dialog modal-dialog-centered" role="document">
+                                                                                    <div class="modal-content">
+                                                                                        <div class="modal-header">
+                                                                                            <h5 class="modal-title">{{ $item['item_code'] }}</h5>
+                                                                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                                                <span aria-hidden="true">&times;</span>
+                                                                                            </button>
                                                                                         </div>
-                                                                                        <div class="col-6" style="display: flex; justify-content: center; align-items: center;">
-                                                                                            <b>{{ $item['item_code'] }}</b>
+                                                                                        <div class="modal-body">
+                                                                                            <form></form>
+                                                                                            <div id="image-container" class="container-fluid">
+                                                                                                <div id="carouselExampleControls" class="carousel slide" data-interval="false">
+                                                                                                    <div class="carousel-inner">
+                                                                                                        <div class="carousel-item active">
+                                                                                                            <picture>
+                                                                                                                <source id="mobile-{{ $item['item_code'] }}-webp-image-src" srcset="{{ asset('storage/').$img_webp }}" type="image/webp" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                <source id="mobile-{{ $item['item_code'] }}-orig-image-src" srcset="{{ asset('storage/').$img }}" type="image/jpeg" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                <img class="d-block w-100" id="mobile-{{ $item['item_code'] }}-image" src="{{ asset('storage/').$img }}" alt="{{ Illuminate\Support\Str::slug(explode('.', $img)[0], '-') }}">
+                                                                                                            </picture>
+                                                                                                        </div>
+                                                                                                        <span class='d-none' id="mobile-{{ $item['item_code'] }}-image-data">0</span>
+                                                                                                    </div>
+                                                                                                    @if ($item['img_count'] > 1)
+                                                                                                    <a class="carousel-control-prev" href="#carouselExampleControls" onclick="prevImg('{{ $item['item_code'] }}')" role="button" data-slide="prev" style="color: #000 !important">
+                                                                                                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                                                                                        <span class="sr-only">Previous</span>
+                                                                                                    </a>
+                                                                                                    <a class="carousel-control-next" href="#carouselExampleControls" onclick="nextImg('{{ $item['item_code'] }}')" role="button" data-slide="next" style="color: #000 !important">
+                                                                                                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                                                                                        <span class="sr-only">Next</span>
+                                                                                                    </a>
+                                                                                                    @endif
+                                                                                                </div>
+                                                                                            </div>
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
-                                                                                <div class="col-3 text-center" style="display: flex; justify-content: center; align-items: center;">
-                                                                                    <b>{{ $item['delivered_qty'] * 1 }}</b>&nbsp;<small>{{ $item['stock_uom'] }}</small>
-                                                                                </div>
-                                                                                <div class="col-3 text-center" style="display: flex; justify-content: center; align-items: center;">
-                                                                                    <span style="white-space: nowrap">₱ {{ number_format($item['price'] * 1, 2) }}</span>
-                                                                                </div>
-                                                                                <div class="col-12 item-description ste-description pt-2 text-justify">
-                                                                                    {{ strip_tags($item['description']) }}
-                                                                                </div>
                                                                             </div>
                                                                         </td>
+                                                                        <td class="text-center p-1 align-middle">
+                                                                            <span class="d-block font-weight-bold">{{ $item['delivered_qty'] * 1 }}</span>
+                                                                            <small>{{ $item['stock_uom'] }}</small>
+                                                                        </td>
+                                                                        <td class="text-center p-1 align-middle">
+                                                                        <span class="d-block font-weight-bold">₱ {{ number_format($item['price'] * 1, 2) }}</span>
+                                                                        </td>
                                                                     </tr>
-                                                                @endforeach
+                                                                    <tr>
+                                                                        <td colspan="3" class="text-justify pt-0 pb-1 pl-1 pr-1" style="border-top: 0 !important;">
+                                                                            <span class="item-description">{!! strip_tags($item['description']) !!}</span>
+                                                                        </td>
+                                                                    </tr>
+                                                                    @endforeach
+                                                                </tbody>
                                                             </table>
                                                         </div>
                                                         @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
-                                                            <div class="modal-footer">
-                                                                <a href="/promodiser/receive/{{ $ste['name'] }}" class="btn btn-primary w-100">Receive</a>
-                                                            </div>
+                                                        <div class="modal-footer">
+                                                            <a href="/promodiser/receive/{{ $ste['name'] }}" class="btn btn-primary w-100">Receive</a>
+                                                        </div>
                                                         @endif
                                                     </div>
                                                 </div>
                                             </div>
                                         </td>
                                     </tr>
-                                @empty
+                                    @empty
                                     <tr>
-                                        <td colspan=2 class="text-center">
+                                        <td colspan="2" class="text-center text-uppercase text-muted align-middle">
                                             @if ($type == 'all')
                                                 No delivery record(s)
                                             @else
                                                 No incoming deliveries
                                             @endif
                                         </td>
-                                    </tr> 
-                                @endforelse
+                                    </tr>
+                                    @endforelse
+                                </tbody>
                             </table>
-                            <div class="mt-3 ml-3 clearfix pagination" style="display: block;">
-                                <div class="col-md-4 float-right">
-                                    {{ $delivery_report->links() }}
-                                </div>
+                            <div class="mt-3 ml-3 clearfix pagination d-block">
+                                <div class="col-md-4 float-right">{{ $delivery_report->links() }}</div>
                             </div>
                         </div>
                     </div>
@@ -152,10 +182,6 @@
 
 @section('style')
     <style>
-        table {
-            table-layout: fixed;
-            width: 100%;   
-        }
         .morectnt span {
             display: none;
         }

--- a/resources/views/consignment/stock_transfer_form.blade.php
+++ b/resources/views/consignment/stock_transfer_form.blade.php
@@ -67,11 +67,80 @@
                                 <div class="row p-1 mt-2" id="items-to-return" style="display: none">
                                     <div class="container-fluid">
                                         <div class="row">
-                                            <div class="col-8">
-                                                <select id="received-items" class="form-control" style="font-size: 9pt;"></select>
+                                            <div class="col-7">
+                                                <input type="text" class="form-control form-control-sm" id="item-search" name="search" autocomplete="off" placeholder="Search"/>
                                             </div>
-                                            <div class="col-4">
-                                                <button type="button" class="btn btn-primary w-100" id="add-item" style="font-size: 10pt" disabled><i class="fa fa-plus"></i> Add item</button>
+                                            <div class="col-5">
+                                                <button type="button" class="btn btn-primary w-100" id="open-item-modal" style="font-size: 10pt;" data-toggle="modal" data-target="#add-item-Modal" disabled><i class="fa fa-plus"></i> Add item</button>
+
+                                                <div class="modal fade" id="add-item-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header bg-navy">
+                                                                <h5 class="modal-title" id="exampleModalLabel">Add an Item</h5>
+                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                    <span aria-hidden="true" style="color: #fff">&times;</span>
+                                                                </button>
+                                                            </div>
+                                                            <div class="modal-body">
+                                                                <select id="received-items" class="form-control" style="font-size: 9pt;"></select>
+                                                                <br><br>
+                                                                <div class="container-fluid d-none" id="items-container">
+                                                                    <table class="table" id='items-selection-table' style="font-size: 10pt;">
+                                                                        <tr>
+                                                                            <th class="text-center" style="width: 40%">Item</th>
+                                                                            <th class="text-center" style="width: 25%">Stocks</th>
+                                                                            <th class="text-center transfer-text">Qty to Transfer</th>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td colspan="3">
+                                                                                <div class="row">
+                                                                                    <div class="p-0 col-2 text-center">
+                                                                                        <picture>
+                                                                                            <source srcset="" id='webp-src-display' type="image/webp">
+                                                                                            <source srcset="" id='img-src-display' type="image/jpeg">
+                                                                                            <img src="" alt="" id='img-src' class="img-thumbnailm" alt="User Image" width="40" height="40">
+                                                                                        </picture>
+                                                                                        <div class="d-none">
+                                                                                            <span id="img-text"></span>
+                                                                                            <span id="webp-text"></span>
+                                                                                            <span id="alt-text"></span>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div class="p-1 col-3 m-0" style="display: flex; justify-content: center; align-items: center;">
+                                                                                        <span id='item-code-text' class="font-weight-bold"></span>
+                                                                                    </div>
+                                                                                    <div class="col-3" style="display: flex; justify-content: center; align-items: center; height: 44px">
+                                                                                        <b><span id="stocks-text"></span></b>&nbsp;<small><span id="uom-text"></span></small>
+                                                                                    </div>
+                                                                                    <div class="col p-0">
+                                                                                        <div class="input-group p-1 ml-3">
+                                                                                            <div class="input-group-prepend p-0">
+                                                                                                <button class="btn btn-outline-danger btn-xs qtyminus" style="padding: 0 5px 0 5px;" type="button">-</button>
+                                                                                            </div>
+                                                                                            <div class="custom-a p-0">
+                                                                                                <input type="text" class="form-control form-control-sm qty" value="0" id="qty-input" data-max="0" style="text-align: center; width: 40px">
+                                                                                            </div>
+                                                                                            <div class="input-group-append p-0">
+                                                                                                <button class="btn btn-outline-success btn-xs qtyplus" style="padding: 0 5px 0 5px;" type="button">+</button>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div class="col-12 text-justify">
+                                                                                        <span id="description-text"></span>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </table>
+                                                                </div>
+                                                            </div>
+                                                            <div class="modal-footer">
+                                                                <button type="button" id="add-item" class="btn btn-primary w-100" disabled>Add item</button>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -82,7 +151,7 @@
                                                 <tr>
                                                     <th class="text-center" style="width: 40%">Item</th>
                                                     <th class="text-center" style="width: 25%">Stocks</th>
-                                                    <th class="text-center" id="transfer-text">Qty to Transfer</th>
+                                                    <th class="text-center transfer-text">Qty to Transfer</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -94,19 +163,10 @@
                                     </div>
 
                                     <div class="container-fluid mt-2 text-center">
-                                        <button type="submit" id="submit-btn" class="btn btn-primary d-none">Submit</button>
+                                        <button type="submit" id="submit-btn" class="btn btn-primary w-100 d-none">Submit</button>
                                     </div>
 
-                                    <div class="d-none"><!-- hidden values, acts as placeholder -->
-                                        <span id="item-code"></span>
-                                        <span id="description"></span>
-                                        <span id="img"></span>
-                                        <span id="webp"></span>
-                                        <span id="alt"></span>
-                                        <span id="stocks"></span>
-                                        <span id="uom"></span>
-                                        <span id="counter">0</span>
-                                    </div>
+                                    <span id="counter" class='d-none'>0</span>
                                 </div>
                             </form>
                         </div>
@@ -136,7 +196,7 @@
             $('#transfer-as').change(function (){
                 $('#target').slideDown();
                 var src = $('#src-warehouse').val();
-                if($(this).val() == 'Store Transfer'){ // Stock Transfers
+                if($(this).val() == 'Store Transfer'){
                     if($('#source').is(':hidden')){
                         $('#source').slideDown();
                     }
@@ -149,8 +209,8 @@
                     }
 
                     $('#src-warehouse').prop('required', true);
-                    $('#transfer-text').text('Qty to Transfer');
-                }else if($(this).val() == 'For Return'){ // For Return
+                    $('.transfer-text').text('Qty to Transfer');
+                }else if($(this).val() == 'For Return'){
                     if($('#source').is(':hidden')){
                         $('#source').slideDown();
                     }
@@ -160,7 +220,7 @@
                     $('#target-warehouse-container').addClass('d-none');
 
                     $('#src-warehouse').prop('required', true);
-                    $('#transfer-text').text('Qty to Transfer');
+                    $('.transfer-text').text('Qty to Transfer');
 
                     $('#items-to-return').slideDown();
                 }else{ // sales returns
@@ -171,7 +231,7 @@
                     $('#target-warehouse').attr("disabled", false);
 
                     $('#src-warehouse').prop('required', false);
-                    $('#transfer-text').text('Qty Returned');
+                    $('.transfer-text').text('Qty Returned');
 
                     if($('#source').is(':visible')){
                         $('#source').slideUp();
@@ -182,6 +242,15 @@
 
                 $("#target-warehouse").empty().trigger('change');
                 $("#received-items").empty().trigger('change');
+
+                $('.items-list').each(function() {
+                    var item_code = $(this).val();
+                    remove_items(item_code);
+                });
+
+                $('#submit-btn').addClass('d-none');
+                $('#placeholder').removeClass('d-none');
+
                 get_received_items(src);
                 reset_placeholders();
             });
@@ -200,6 +269,7 @@
                     remove_items(item_code);
                 });
                 
+                $('#open-item-modal').prop('disabled', false);
                 reset_placeholders();
                 validate_submit();
             });
@@ -240,6 +310,7 @@
                     reset_placeholders();
 
                     $('#placeholder').removeClass('d-none');
+                    $('#open-item-modal').prop('disabled', false);
                 }
             });
 
@@ -265,36 +336,28 @@
                     }
                 });
             }
-            
+
             validate_submit();
             function validate_submit(){
                 var inputs = new Array();
                 var max_check = new Array();
 
-                $('.to-return').each(function (){
+                $('.validate.qty.to-return').each(function (){
                     var max = $(this).data('max');
                     var val = $(this).val();
 
-                    if(val <= max){
+                    if($.isNumeric(val) && parseInt(val) > 0 && parseInt(val) <= parseInt(max)){
                         $(this).css('border', '1px solid #CED4DA');
+                        inputs.push(1);
                     }else{
                         $(this).css('border', '1px solid red');
+                        inputs.push(0);
                     }
-
-                    inputs.push(val);
-                    max_check.push((max >= val ? 1 : 0));
                 });
 
-                var stocks_checker = Math.min.apply(Math, max_check);
+                var stocks_check = inputs.length > 0 ? Math.min.apply(Math, inputs) : 0;
 
-                var min = Math.min.apply(Math, inputs);
-                if(min > 0){
-                    $('#counter').text(inputs.length);
-                }else{
-                    $('#counter').text(0);
-                }
-
-                if(parseInt($('#counter').text()) > 0 && inputs.length > 0 && stocks_checker == 1){
+                if(parseInt($('#counter').text()) > 0 && stocks_check == 1){
                     $('#submit-btn').prop('disabled', false);
                 }else{
                     $('#submit-btn').prop('disabled', true);
@@ -302,47 +365,105 @@
             }
 
             function remove_items(item_code){
-                $('#' + item_code).val('');
-                $('.row-' + item_code).addClass('d-none');
-                $('#qty-' + item_code).removeClass('to-return');
-                $('#qty-' + item_code).attr('name', '');
+                $('.row-' + item_code).remove();
+                var val = parseInt($('#counter').text()) - 1;
+                val = val > 0 ? val : 0;
+                $('#counter').text(val);
             }
 
             function reset_placeholders(){
-                $('#item-code').text('');
-                $('#description').text('');
-                $('#img').text('');
-                $('#webp').text('');
-                $('#alt').text('');
-                $('#stocks').text('');
-                $('#uom').text('');
-
-                $('#add-item').prop('disabled', true);
+                $('#qty-input').val(0);
+                $('#img-text').text(null);
+                $('#alt-text').text(null);
+                $('#uom-text').text(null);
+                $('#webp-text').text(null);
+                $('#stocks-text').text(null);
+                $('#qty-input').data('max', 0);
+                $('#img-src').attr('src', null);
+                $('#item-code-text').text(null);
+                $('#description-text').text(null);
+                $('#img-src-display').attr('src', null);
+                $('#webp-src-display').attr('src', null);
             }
             
             $(document).on('select2:select', '#received-items', function(e){
-                $('#item-code').text(e.params.data.id);
-                $('#description').text(e.params.data.description);
-                $('#img').text(e.params.data.img);
-                $('#webp').text(e.params.data.webp);
-                $('#alt').text(e.params.data.alt);
-                $('#stocks').text(e.params.data.max);
-                $('#uom').text(e.params.data.uom);
+                $('#img-text').text(e.params.data.img);
+                $('#alt-text').text(e.params.data.alt);
+                $('#uom-text').text(e.params.data.uom);
+                $('#webp-text').text(e.params.data.webp);
+                $('#stocks-text').text(e.params.data.max);
+                $('#item-code-text').text(e.params.data.id);
+                $('#img-src').attr('src', e.params.data.img);
+                $('#qty-input').data('max', e.params.data.max);
+                $('#img-src-display').attr('src', e.params.data.img);
+                $('#webp-src-display').attr('src', e.params.data.webp);
+                $('#description-text').text(e.params.data.description);
                 
                 $('#add-item').prop('disabled', false);
+                $('#items-container').removeClass('d-none');
+            });
+
+            // Modal Add/Subtract Controls
+            $('table#items-selection-table').on('click', '.qtyplus', function(e){
+                // Stop acting like a button
+                e.preventDefault();
+                // Get the field name
+                var fieldName = $(this).parents('.input-group').find('.qty').eq(0);
+                var max = fieldName.data('max');
+                // Get its current value
+                var currentVal = parseInt(fieldName.val());
+                // If is not undefined
+                if (!isNaN(currentVal)) {
+                    // Increment
+                    if (currentVal < max) {
+                        fieldName.val(currentVal + 1);
+                    }
+                } else {
+                    // Otherwise put a 0 there
+                    fieldName.val(0);
+                }
+
+            });
+
+            $('table#items-selection-table').on('click', '.qtyminus', function(e){
+                // Stop acting like a button
+                e.preventDefault();
+                // Get the field name
+                var fieldName = $(this).parents('.input-group').find('.qty').eq(0);
+                // Get its current value
+                var currentVal = parseInt(fieldName.val());
+                // If it isn't undefined or its greater than 0
+                if (!isNaN(currentVal) && currentVal > 0) {
+                    // Decrement one
+                    fieldName.val(currentVal - 1);
+                } else {
+                    // Otherwise put a 0 there
+                    fieldName.val(0);
+                }
+
+            });
+            // Modal Add/Subtract Controls
+
+            $("#item-search").on("keyup", function() {
+                var value = $(this).val().toLowerCase();
+                $("#items-table tr").filter(function() {
+                    $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+                });
             });
 
             $('#add-item').click(function (){
-                var item_code = $('#item-code').text();
-                var description = $('#description').text();
-                var img = $('#img').text();
-                var webp = $('#webp').text();
-                var alt = $('#alt').text();
-                var stocks = $('#stocks').text();
-                var uom = $('#uom').text();
+                var img = $('#img-text').text();
+                var alt = $('#alt-text').text();
+                var qty = $('#qty-input').val();
+                var uom = $('#uom-text').text();
+                var webp = $('#webp-text').text();
+                var stocks = $('#stocks-text').text();
+                var item_code = $('#item-code-text').text();
+                var description = $('#description-text').text();
 
                 var row = '<tr class="row-' + item_code + '">' +
                     '<td colspan=3 class="text-center p-0">' +
+                        '<div class="d-none">' + description + '</div>' + // reference for search
                         '<div class="row">' +
                             '<input name="item_code[]" class="items-list d-none" value="' + item_code + '" id="' + item_code + '" />' +
                             '<div class="p-1 col-2 text-center">' +
@@ -364,7 +485,7 @@
                                         '<button class="btn btn-outline-danger btn-xs qtyminus" style="padding: 0 5px 0 5px;" type="button">-</button>' +
                                     '</div>' +
                                     '<div class="custom-a p-0">' +
-                                        '<input type="text" class="form-control form-control-sm qty validate to-return" id="qty-' + item_code + '" value="0" data-item-code="' + item_code + '" name="item[' + item_code + '][transfer_qty]" data-max="' + stocks + '" style="text-align: center; width: 40px">' +
+                                        '<input type="text" class="form-control form-control-sm validate qty to-return" id="qty-' + item_code + '" value="' + qty + '" data-item-code="' + item_code + '" name="item[' + item_code + '][transfer_qty]" data-max="' + stocks + '" style="text-align: center; width: 40px">' +
                                     '</div>' +
                                     '<div class="input-group-append p-0">' +
                                         '<button class="btn btn-outline-success btn-xs qtyplus" style="padding: 0 5px 0 5px;" type="button">+</button>' +
@@ -379,16 +500,22 @@
                 '</tr>' +
                 '<tr class="row-' + item_code + '">' +
                     '<td colspan=3 class="text-justify p-2" style="font-size: 10pt;">' +
+                        '<div class="d-none">' + item_code + '</div>' + // reference for search
                         '<div class="item-description">' + description + '</div>' +
                     '</td>' +
                 '</tr>';
 
-                $('#items-table tbody').prepend(row);
+                $('#counter').text(parseInt($('#counter').text()) + 1);
+                $("#received-items").empty().trigger('change');
+                $('#items-container').addClass('d-none');
                 $('#submit-btn').removeClass('d-none');
+                $('#add-item').prop('disabled', true);
+                $('#items-table tbody').prepend(row);
                 $('#placeholder').addClass('d-none');
 
-                $("#received-items").empty().trigger('change');
+                close_modal('add-item-Modal');
                 reset_placeholders();
+                validate_submit();
                 cut_text();
             });
 
@@ -458,22 +585,22 @@
                         $(this).html(txt);
                     }
                 });
-
-                $(".show-more").click(function(e) {
-                    e.preventDefault();
-                    if ($(this).hasClass("sample")) {
-                        $(this).removeClass("sample");
-                        $(this).text(showChar);
-                    } else {
-                        $(this).addClass("sample");
-                        $(this).text(hideChar);
-                    }
-
-                    $(this).parent().prev().toggle();
-                    $(this).prev().toggle();
-                    return false;
-                });
             }
+
+            $(".show-more").click(function(e) {
+                e.preventDefault();
+                if ($(this).hasClass("sample")) {
+                    $(this).removeClass("sample");
+                    $(this).text(showChar);
+                } else {
+                    $(this).addClass("sample");
+                    $(this).text(hideChar);
+                }
+
+                $(this).parent().prev().toggle();
+                $(this).prev().toggle();
+                return false;
+            });
         });
     </script>
 @endsection

--- a/resources/views/consignment/supervisor/tbl_activity_logs.blade.php
+++ b/resources/views/consignment/supervisor/tbl_activity_logs.blade.php
@@ -1,21 +1,21 @@
 <table class="table table-striped" style="font-size: 9pt;">
     <thead>
-        <th class="text-center align-middle p-1" style="width: 15%;">Transaction Date</th>
-        <th class="text-center align-middle p-1" style="width: 55%;">Subject</th>
-        <th class="text-center align-middle p-1" style="width: 15%;">Ref. No.</th>
-        <th class="text-center align-middle p-1" style="width: 15%;">Created by</th>
+        <th class="text-center align-middle p-2" style="width: 18%;">Transaction Date</th>
+        <th class="text-center align-middle p-2" style="width: 52%;">Subject</th>
+        <th class="text-center align-middle p-2" style="width: 15%;">Ref. No.</th>
+        <th class="text-center align-middle p-2" style="width: 15%;">Created by</th>
     </thead>
     <tbody>
         @forelse ($logs as $r)
         <tr>
-            <td class="text-center align-middle p-1">{{ \Carbon\Carbon::parse($r->creation)->format('F d, Y h:i A') }}</td>
-            <td class="text-justify align-middle p-1">{{ $r->subject }}</td>
-            <td class="text-center align-middle p-1">{{ $r->reference_name }}</td>
-            <td class="text-center align-middle p-1">{{ $r->full_name }}</td>
+            <td class="text-center align-middle p-2">{{ \Carbon\Carbon::parse($r->creation)->format('F d, Y h:i A') }}</td>
+            <td class="text-justify align-middle p-2">{{ $r->subject }}</td>
+            <td class="text-center align-middle p-2">{{ $r->reference_name }}</td>
+            <td class="text-center align-middle p-2">{{ $r->full_name }}</td>
         </tr>
         @empty
         <tr>
-            <td colspan="4" class="text-center text-uppercase text-muted p-1">No record(s) found</td>
+            <td colspan="4" class="text-center text-uppercase text-muted p-2">No record(s) found</td>
         </tr>
         @endforelse
     </tbody>

--- a/resources/views/consignment/supervisor/tbl_inventory_audit_history.blade.php
+++ b/resources/views/consignment/supervisor/tbl_inventory_audit_history.blade.php
@@ -1,20 +1,28 @@
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped" style="font-size: 9pt;">
     <thead>
-        <th class="text-center font-responsive align-middle p-2">Store</th>
+        <th class="text-center font-responsive align-middle p-2">Transaction Date</th>
+        <th class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">Store</th>
         <th class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">Period</th>
+        <th class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">Total Qty Sold</th>
         <th class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">Total Sales</th>
+        <th class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">Promodiser</th>
         <th class="text-center font-responsive align-middle p-2">Action</th>
     </thead>
     <tbody>
         @forelse($result as $row)
         <tr>
+            <td class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">{{ \Carbon\Carbon::parse($row['transaction_date'])->format('F d, Y') }}</td>
             <td class="text-left font-responsive align-middle p-2">
                 <span class="d-lg-none">{{ \Carbon\Carbon::parse($row['audit_date_from'])->format('F d, Y') }} - {{ \Carbon\Carbon::parse($row['audit_date_to'])->format('F d, Y') }}</span>
                 <span class="d-block">{{ $row['branch_warehouse'] }}</span>
-                <span class="d-lg-none"><b>Total Sales: </b>{{ '₱ ' . number_format($row['total_sales'], 2) }}</span>
+                <span class="d-block d-lg-none"><b>Total Qty Sold: </b>{{ number_format($row['total_qty_sold']) }}</span>
+                <span class="d-block d-lg-none"><b>Total Sales: </b>{{ '₱ ' . number_format($row['total_sales'], 2) }}</span>
+                <span class="d-block d-lg-none">{{ $row['promodiser'] }} - {{ \Carbon\Carbon::parse($row['transaction_date'])->format('F d, Y') }}</span>
             </td>
             <td class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">{{ \Carbon\Carbon::parse($row['audit_date_from'])->format('F d, Y') }} - {{ \Carbon\Carbon::parse($row['audit_date_to'])->format('F d, Y') }}</td>
+            <td class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">{{ number_format($row['total_qty_sold']) }}</td>
             <td class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">{{ '₱ ' . number_format($row['total_sales'], 2) }}</td>
+            <td class="text-center font-responsive align-middle p-2 d-none d-lg-table-cell">{{ $row['promodiser'] }}</td>
             <td class="text-center font-responsive align-middle p-2">
                 <a href="/view_inventory_audit_items/{{ $row['branch_warehouse'] }}/{{ $row['audit_date_from'] }}/{{ $row['audit_date_to'] }}" class="btn btn-info btn-sm" style="width: 70px;"><i class="fas fa-search"></i></a>
             </td>

--- a/resources/views/consignment/supervisor/view_promodisers_list.blade.php
+++ b/resources/views/consignment/supervisor/view_promodisers_list.blade.php
@@ -51,7 +51,7 @@
                                     </tr>
                                     @empty
                                     <tr>
-                                        <td class="text-center font-weight-bold text-uppercase text-muted" colspan="3">No record(s) found</td>
+                                        <td class="text-center font-weight-bold text-uppercase text-muted" colspan="4">No record(s) found</td>
                                     </tr> 
                                     @endforelse
                                 </tbody>

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -84,7 +84,7 @@
                                                         <input type="text" name="date" id="date-filter" class="form-control filters-font" value="" />
                                                     </div>
                                                     <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
-                                                        <button type="submit" class="btn btn-primary filters-font"><i class="fas fa-search"></i> Search</button>
+                                                        <button type="submit" class="btn btn-primary filters-font btn-block"><i class="fas fa-search"></i> Search</button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -276,9 +276,9 @@
                                                                                         @endif
                                                                                     </td>
                                                                                     @if ($inv['status'] == 'Approved')
-                                                                                        <td class="text-center p-1 align-middle">
-                                                                                            <span class="btn btn-primary btn-xs edit-stock_qty" data-reference="{{ $inv['name'].'-'.$item['item_code'] }}" data-name="{{ $inv['name'] }}"><i class="fa fa-edit"></i></span>
-                                                                                        </td>
+                                                                                    <td class="text-center p-1 align-middle">
+                                                                                        <span class="btn btn-primary btn-xs edit-stock_qty" data-reference="{{ $inv['name'].'-'.$item['item_code'] }}" data-name="{{ $inv['name'] }}"><i class="fa fa-edit"></i></span>
+                                                                                    </td>
                                                                                     @endif
                                                                                 </tr>
                                                                                 <tr class="d-xl-none">

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -73,7 +73,7 @@
                                                         </select>
                                                     </div>
                                                     <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
-                                                        <select name="store" class="form-control filters-font">
+                                                        <select name="store" class="form-control filters-font" id="consignment-store-select">
                                                             <option value="" disabled {{ !request('store') ? 'selected' : null }}>Select a store</option>
                                                             @foreach ($consignment_stores as $store)
                                                             <option value="{{ $store }}" {{ request('store') == $store ? 'selected' : null }}>{{ $store }}</option>
@@ -543,6 +543,26 @@
                 $('#headingOne').addClass('d-none');
                 $('#collapseOne').addClass('show');
 			}
+
+            $('#consignment-store-select').select2({
+            placeholder: "Select Store",
+            ajax: {
+                url: '/consignment_stores',
+                method: 'GET',
+                dataType: 'json',
+                data: function (data) {
+                    return {
+                        q: data.term // search term
+                    };
+                },
+                processResults: function (response) {
+                    return {
+                        results: response
+                    };
+                },
+                cache: true
+            }
+        });
         });
     </script>
 @endsection

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -38,241 +38,283 @@
 
                             <div class="tab-content">
                                 <div class="tab-pane fade show active" id="pending-content" role="tabpanel" aria-labelledby="pending-tab">
-                                    <div class="container-fluid p-0">
-                                        <div id="beginning_inventory" class="container-fluid">
-                                            <form action="/beginning_inv_list" method="get">
-                                                <div id="accordion">
-                                                    <div class="card" style='border: none !important; box-shadow: none !important'>
-                                                        <div class="card-header p-0" id="headingOne">
-                                                            <h5 class="mb-0">
-                                                            <button type="button" class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne" style="font-size: 10pt;">
-                                                                <i class="fa fa-filter"></i> Filters
-                                                            </button>
-                                                            </h5>
-                                                        </div>
-                                                    
-                                                        <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
-                                                            <div class="card-body p-0">
-                                                                <div class="row p-2">
-                                                                    <div class="col-12 col-lg-2 col-xl-2 offset-xl-3">
-                                                                        <input type="text" class="form-control filters-font" name="search" value="{{ request('search') ? request('search') : null }}" placeholder="Search"/>
-                                                                    </div>
-                                                                    <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
-                                                                        @php
-                                                                            $statuses = ['For Approval', 'Approved', 'Cancelled'];
-                                                                        @endphp
-                                                                        <select name="status" class="form-control filters-font">
-                                                                            <option value="" disabled {{ Auth::user()->user_group == 'Promodiser' && !request('status') ? 'selected' : null }}>Select a status</option>
-                                                                            <option value="All" {{ request('status') ? ( request('status') == 'All' ? 'selected' : null) : null }}>Select All</option>
-                                                                            @foreach ($statuses as $status)
-                                                                                @php
-                                                                                    $selected = null;
-                                                                                    if(request('status')){
-                                                                                        if(request('status') == $status){
-                                                                                            $selected = 'selected';
-                                                                                        }
-                                                                                    }else{
-                                                                                        if(Auth::user()->user_group == 'Consignment Supervisor'){
-                                                                                            $selected = $status == 'For Approval' ? 'selected' : null;
-                                                                                        }
-                                                                                    }
-                                                                                @endphp
-                                                                                <option value="{{ $status }}" {{ $selected }}>{{ $status }}</option>
-                                                                            @endforeach
-                                                                        </select>
-                                                                    </div>
-                                                                    <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
-                                                                        <select name="store" class="form-control filters-font">
-                                                                            <option value="" disabled {{ !request('store') ? 'selected' : null }}>Select a store</option>
-                                                                            @foreach ($consignment_stores as $store)
-                                                                                <option value="{{ $store }}" {{ request('store') == $store ? 'selected' : null }}>{{ $store }}</option>
-                                                                            @endforeach
-                                                                        </select>
-                                                                    </div>
-                                                                    <div class="col-12 col-lg-4 col-xl-2 mt-2 mt-lg-0">
-                                                                        <input type="text" name="date" id="date-filter" class="form-control filters-font" value="" />
-                                                                    </div>
-                                                                    <div class="col-12 col-lg-2 col-xl-1 mt-2 mt-lg-0">
-                                                                        <button type="submit" class="btn btn-primary filters-font w-100" >Search</button>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        </div>
+                                    <form action="/beginning_inv_list" method="get">
+                                        <div id="accordion" class="mt-2">
+                                            <button type="button" class="btn btn-link border-bottom btn-block text-left d-xl-none d-lg-none" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne" style="font-size: 10pt;">
+                                                <i class="fa fa-filter"></i> Filters
+                                            </button>
+                                            <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
+                                                <div class="row p-2">
+                                                    <div class="col-12 col-lg-3 col-xl-3">
+                                                        <input type="text" class="form-control filters-font" name="search" value="{{ request('search') ? request('search') : null }}" placeholder="Search"/>
+                                                    </div>
+                                                    <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
+                                                        @php
+                                                            $statuses = ['For Approval', 'Approved', 'Cancelled'];
+                                                        @endphp
+                                                        <select name="status" class="form-control filters-font">
+                                                            <option value="" disabled {{ Auth::user()->user_group == 'Promodiser' && !request('status') ? 'selected' : null }}>Select a status</option>
+                                                            <option value="All" {{ request('status') ? ( request('status') == 'All' ? 'selected' : null) : null }}>Select All</option>
+                                                            @foreach ($statuses as $status)
+                                                            @php
+                                                                $selected = null;
+                                                                if(request('status')){
+                                                                    if(request('status') == $status){
+                                                                        $selected = 'selected';
+                                                                    }
+                                                                }else{
+                                                                    if(Auth::user()->user_group == 'Consignment Supervisor'){
+                                                                        $selected = $status == 'For Approval' ? 'selected' : null;
+                                                                    }
+                                                                }
+                                                            @endphp
+                                                            <option value="{{ $status }}" {{ $selected }}>{{ $status }}</option>
+                                                            @endforeach
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
+                                                        <select name="store" class="form-control filters-font">
+                                                            <option value="" disabled {{ !request('store') ? 'selected' : null }}>Select a store</option>
+                                                            @foreach ($consignment_stores as $store)
+                                                            <option value="{{ $store }}" {{ request('store') == $store ? 'selected' : null }}>{{ $store }}</option>
+                                                            @endforeach
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 col-lg-3 col-xl-3 mt-2 mt-lg-0">
+                                                        <input type="text" name="date" id="date-filter" class="form-control filters-font" value="" />
+                                                    </div>
+                                                    <div class="col-12 col-lg-2 col-xl-2 mt-2 mt-lg-0">
+                                                        <button type="submit" class="btn btn-primary filters-font"><i class="fas fa-search"></i> Search</button>
                                                     </div>
                                                 </div>
-                                            </form>
-        
-                                            <table class="table table-striped" style="font-size: 10pt;">
-                                                <tr>
-                                                    <th class="font-responsive text-center d-none d-lg-table-cell">Date</th>
-                                                    <th class="font-responsive text-center">Branch</th>
-                                                    <th class="font-responsive text-center d-none d-lg-table-cell">Submitted by</th>
-                                                    <th class="font-responsive text-center d-none d-lg-table-cell">Status</th>
-                                                    <th class="font-responsive text-center last-row">Action</th>
-                                                </tr>
-                                                @forelse ($inv_arr as $inv)
-                                                    @php
-                                                        $badge = 'secondary';
-                                                        if($inv['status'] == 'For Approval'){
-                                                            $badge = 'primary';
-                                                        }else if($inv['status'] == 'Approved'){
-                                                            $badge = 'success';
-                                                        }else if($inv['status'] == 'Cancelled'){
-                                                            $badge = 'danger';
-                                                        }
-        
-                                                        $modal_form = Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval' ? '/approve_beginning_inv/'.$inv['name'] : '/stock_adjust/submit/'.$inv['name'];
-                                                    @endphp
-                                                    <tr>
-                                                        <td class="font-responsive text-center d-none d-lg-table-cell">
-                                                            <span style="white-space: nowrap">{{ $inv['transaction_date'] }}</span>
-                                                        </td>
-                                                        <td class="font-responsive text-left text-xl-center">
-                                                            {{ $inv['branch'] }}
-                                                            <div class="row pl-2 d-block text-left d-lg-none">
-                                                                <b>By:</b>&nbsp;{{ $inv['owner'] }} <br>
-                                                                <b>Date:</b>&nbsp;<span style="white-space: nowrap">{{ $inv['transaction_date'] }}</span>
-                                                            </div>
-                                                        </td>
-                                                        <td class="font-responsive text-center d-none d-lg-table-cell">{{ $inv['owner'] }}</td>
-                                                        <td class="font-responsive text-center d-none d-lg-table-cell">
-                                                            <span class="badge badge-{{ $badge }}">{{ $inv['status'] }}</span>
-                                                        </td>
-                                                        <td class="font-responsive text-center p-0 pt-3">
-                                                            <a href="#" data-toggle="modal" data-target="#{{ $inv['name'] }}-Modal">
-                                                                View Items
-                                                            </a>
-                                                            <span class="badge badge-{{ $badge }} d-xl-none">{{ $inv['status'] }}</span>
-                                                                
-                                                            <div class="modal fade" id="{{ $inv['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                                                                <div class="modal-dialog modal-xl" role="document">
-                                                                    <div class="modal-content">
-                                                                        <form action="{{ $modal_form }}" method="post">
-                                                                            @csrf
-                                                                            <div class="modal-header" style="background-color: #001F3F; color: #fff;">
-                                                                                <div class="container-fluid">
-                                                                                    <div class="row">
-                                                                                        <div class="col-8 text-left font-responsive">
-                                                                                        <h4>{{ $inv['branch'] }}</h4>
-                                                                                        Inventory Date:<b>{{ $inv['transaction_date'] }} </b><br>
-                                                                                        Submitted By:<b>{{ $inv['owner'] }}</b>
+                                            </div>
+                                        </div>
+                                    </form>
+                                    
+                                    <table class="table table-striped" style="font-size: 9pt;">
+                                        <thead>
+                                            <th class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">Date</th>
+                                            <th class="font-responsive align-middle p-2 text-center">Store</th>
+                                            <th class="font-responsive align-middle p-2 text-center">Total Qty</th>
+                                            <th class="font-responsive align-middle p-2 text-center">Total Value</th>
+                                            <th class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">Submitted by</th>
+                                            <th class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">Status</th>
+                                            <th class="font-responsive align-middle p-2 text-center last-ro1w">Action</th>
+                                        </thead>
+                                        @forelse ($inv_arr as $inv)
+                                            @php
+                                                $badge = 'secondary';
+                                                if($inv['status'] == 'For Approval'){
+                                                    $badge = 'primary';
+                                                }else if($inv['status'] == 'Approved'){
+                                                    $badge = 'success';
+                                                }else if($inv['status'] == 'Cancelled'){
+                                                    $badge = 'danger';
+                                                }
+
+                                                $modal_form = Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval' ? '/approve_beginning_inv/'.$inv['name'] : '/stock_adjust/submit/'.$inv['name'];
+                                            @endphp
+                                            <tr>
+                                                <td class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">
+                                                    <span style="white-space: nowrap">{{ $inv['transaction_date'] }}</span>
+                                                </td>
+                                                <td class="font-responsive align-middle p-2 text-left text-xl-center">
+                                                    <span class="d-block">{{ $inv['branch'] }}</span>
+                                                    <small class="d-block text-left d-lg-none">
+                                                        <span class="d-block"><b>By:</b>&nbsp;{{ $inv['owner'] }}</span>
+                                                        <span class="d-block"><b>Date:</b>&nbsp;{{ $inv['transaction_date'] }}</span>
+                                                    </small>
+                                                </td>
+                                                <td class="font-responsive align-middle p-2 text-center">{{ number_format($inv['qty']) }}</td>
+                                                <td class="font-responsive align-middle p-2 text-center">{{ '₱ ' . number_format($inv['amount'], 2) }}</td>
+                                                <td class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">{{ $inv['owner'] }}</td>
+                                                <td class="font-responsive align-middle p-2 text-center d-none d-lg-table-cell">
+                                                    <span class="badge badge-{{ $badge }}">{{ $inv['status'] }}</span>
+                                                </td>
+                                                <td class="font-responsive align-middle p-2 text-center">
+                                                    <a href="#" class="d-block" data-toggle="modal" data-target="#{{ $inv['name'] }}-Modal">View Items</a>
+                                                    <span class="badge badge-{{ $badge }} d-xl-none d-lg-none">{{ $inv['status'] }}</span>
+                                                        
+                                                    <div class="modal fade" id="{{ $inv['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                        <div class="modal-dialog modal-xl" role="document">
+                                                            <div class="modal-content">
+                                                                <form action="{{ $modal_form }}" method="post">
+                                                                    @csrf
+                                                                    <div class="modal-header bg-navy">
+                                                                        <h6 class="modal-title">{{ $inv['branch'] }} <span class="badge badge-{{ $badge }} d-inline-block ml-2">{{ $inv['status'] }}</span></h6>
+                                                                        <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
+                                                                            <span aria-hidden="true">&times;</span>
+                                                                        </button>
+                                                                    </div>
+                                                                    <div class="modal-body">
+                                                                        <div class="row">
+                                                                            <div class="pt-0 pr-2 pl-2 pb-2 col-6 col-lg-4 col-xl-4 text-left">
+                                                                                <dl class="row">
+                                                                                    <dt class="col-12 col-xl-4 col-lg-6">Inventory Date:</dt>
+                                                                                    <dd class="col-12 col-xl-8 col-lg-6">{{ $inv['transaction_date'] }}</dd>
+                                                                                  
+                                                                                    <dt class="col-12 col-xl-4 col-lg-6">Submitted By:</dt>
+                                                                                    <dd class="col-12 col-xl-8 col-lg-6">{{ $inv['owner'] }}</dd>
+                                                                                </dl>
+                                                                            </div>
+                                                                            <div class="pt-0 pr-2 pl-2 pb-2 col-6 col-lg-4 col-xl-4 text-left">
+                                                                                <dl class="row">
+                                                                                    <dt class="col-12 col-xl-4 col-lg-6">Total Qty:</dt>
+                                                                                    <dd class="col-12 col-xl-8 col-lg-6">{{ number_format($inv['qty']) }}</dd>
+                                                                                  
+                                                                                    <dt class="col-12 col-xl-4 col-lg-6">Total Value:</dt>
+                                                                                    <dd class="col-12 col-xl-8 col-lg-6">{{ '₱ ' . number_format($inv['amount'], 2) }}</dd>
+                                                                                </dl>
+                                                                            </div>
+                                                                            <div class="pt-0 pr-2 pl-2 pb-2 col-12 col-lg-4 col-xl-4 text-left">
+                                                                                @if (Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval')
+                                                                                @php
+                                                                                    $status_selection = [
+                                                                                        ['title' => 'Approve', 'value' => 'Approved'],
+                                                                                        ['title' => 'Cancel', 'value' => 'Cancelled']
+                                                                                    ];
+                                                                                @endphp
+                                                                                        
+                                                                                <div class="input-group">
+                                                                                    <select class="custom-select font-responsive" name="status" id="inputGroupSelect04" required>
+                                                                                        <option value="" selected disabled>Select a status</option>
+                                                                                        @foreach ($status_selection as $status)
+                                                                                        <option value="{{ $status['value'] }}">{{ $status['title'] }}</option>
+                                                                                        @endforeach
+                                                                                    </select>
+                                                                                    <div class="input-group-append">
+                                                                                        <button class="btn btn-primary" type="submit">Submit</button>
+                                                                                    </div>
+                                                                                </div>
+                                                                                @endif
+                                                                            </div>
+                                                                        </div>
+                                                                        
+                                                                        <table class="table table-striped" style="font-size: 10pt;">
+                                                                            <thead>
+                                                                                <th class="text-center p-2 align-middle col-lg-4 col-3">Item Code</th>
+                                                                                <th class="text-center p-2 align-middle col-lg-2 col-3">Opening Stock</th>
+                                                                                <th class="text-center p-2 align-middle col-lg-2 col-3">Price</th>
+                                                                                @if ($inv['status'] == 'Approved')
+                                                                                <th class="text-center p-2 align-middle col-lg-2 col-3">-</th>
+                                                                                @endif
+                                                                            </thead>
+                                                                            @forelse ($inv['items'] as $item)
+                                                                                @php
+                                                                                    $img = $item['image'] ? "/img/" . $item['image'] : "/icon/no_img.png";
+                                                                                    $img_webp = $item['image'] ? "/img/" . explode('.', $item['image'])[0].'.webp' : "/icon/no_img.webp";
+                                                                                @endphp
+                                                                                <tr>
+                                                                                    <td class="text-center p-1 align-middle">
+                                                                                        <div class="d-flex flex-row justify-content-start align-items-center">
+                                                                                            <div class="p-2 text-left">
+                                                                                                <a href="{{ asset('storage/') }}{{ $img }}" data-toggle="mobile-lightbox" data-gallery="{{ $item['item_code'] }}" data-title="{{ $item['item_code'] }}">
+                                                                                                    <picture>
+                                                                                                        <source srcset="{{ asset('storage'.$img_webp) }}" type="image/webp" width="60" height="60">
+                                                                                                        <source srcset="{{ asset('storage'.$img) }}" type="image/jpeg" width="60" height="60">
+                                                                                                        <img src="{{ asset('storage'.$img) }}" alt="{{ str_slug(explode('.', $img)[0], '-') }}" width="60" height="60">
+                                                                                                    </picture>
+                                                                                                </a>
+                                                                                            </div>
+                                                                                            <div class="p-2 text-left">
+                                                                                                <b>{!! ''.$item['item_code'] !!}</b>
+                                                                                                <span class="d-none d-xl-inline"> - {!! strip_tags($item['item_description']) !!}</span>
+                                                                                            </div>
                                                                                         </div>
-                                                                                        @if (Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval')
-                                                                                            <div class="col-12 col-xl-4 w-100">
-                                                                                                @php
-                                                                                                    $status_selection = [
-                                                                                                        ['title' => 'Approve', 'value' => 'Approved'],
-                                                                                                        ['title' => 'Cancel', 'value' => 'Cancelled']
-                                                                                                    ];
-                                                                                                @endphp
-                                                                                                
-                                                                                                <div class="input-group pt-2">
-                                                                                                    <select class="custom-select font-responsive" name="status" id="inputGroupSelect04" required>
-                                                                                                        <option value="" selected disabled>Select a status</option>
-                                                                                                        @foreach ($status_selection as $status)
-                                                                                                            <option value="{{ $status['value'] }}">{{ $status['title'] }}</option>                                                                                
-                                                                                                        @endforeach
-                                                                                                    </select>
-                                                                                                    <div class="input-group-append">
-                                                                                                        <button class="btn btn-outline-secondary" type="submit" style="color: #fff">Submit</button>
+                                                                                        <div class="modal fade" id="mobile-{{ $item['item_code'] }}-images-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                                                            <div class="modal-dialog modal-dialog-centered" role="document">
+                                                                                                <div class="modal-content">
+                                                                                                    <div class="modal-header">
+                                                                                                        <h5 class="modal-title">{{ $item['item_code'] }}</h5>
+                                                                                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                                                        <span aria-hidden="true">&times;</span>
+                                                                                                        </button>
+                                                                                                    </div>
+                                                                                                    <div class="modal-body">
+                                                                                                        <form></form>
+                                                                                                        <div class="container-fluid">
+                                                                                                            <div id="carouselExampleControls" class="carousel slide" data-interval="false">
+                                                                                                                <div class="carousel-inner">
+                                                                                                                    <div class="carousel-item active">
+                                                                                                                        <picture>
+                                                                                                                            <source id="mobile-{{ $item['item_code'] }}-webp-image-src" srcset="{{ asset('storage/').$img_webp }}" type="image/webp" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                            <source id="mobile-{{ $item['item_code'] }}-orig-image-src" srcset="{{ asset('storage/').$img }}" type="image/jpeg" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                            <img class="d-block w-100" id="mobile-{{ $item['item_code'] }}-image" src="{{ asset('storage/').$img }}" alt="{{ Illuminate\Support\Str::slug(explode('.', $img)[0], '-') }}">
+                                                                                                                        </picture>
+                                                                                                                    </div>
+                                                                                                                    <span class='d-none' id="mobile-{{ $item['item_code'] }}-image-data">0</span>
+                                                                                                                </div>
+                                                                                                                @if ($item['img_count'] > 1)
+                                                                                                                <a class="carousel-control-prev" href="#carouselExampleControls" onclick="prevImg('{{ $item['item_code'] }}')" role="button" data-slide="prev" style="color: #000 !important">
+                                                                                                                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                                                                                                    <span class="sr-only">Previous</span>
+                                                                                                                </a>
+                                                                                                                <a class="carousel-control-next" href="#carouselExampleControls" onclick="nextImg('{{ $item['item_code'] }}')" role="button" data-slide="next" style="color: #000 !important">
+                                                                                                                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                                                                                                    <span class="sr-only">Next</span>
+                                                                                                                </a>
+                                                                                                                @endif
+                                                                                                            </div>
+                                                                                                        </div>
                                                                                                     </div>
                                                                                                 </div>
                                                                                             </div>
-                                                                                        @endif
-                                                                                    </div>
-                                                                                </div>
-                                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                                                    <span aria-hidden="true" style="color: #fff">&times;</span>
-                                                                                </button>
-                                                                            </div>
-                                                                            <div class="modal-body">
-                                                                                <table class="table table-striped">
-                                                                                    <tr>
-                                                                                        <th class="text-center" style="width: 65%; font-size: 10pt">Item</th>
-                                                                                        <th class="text-center" style="width: 12%; font-size: 10pt">Opening Stock</th>
-                                                                                        <th class="text-center" style="width: 12%; font-size: 10pt">Price</th>
+                                                                                        </div>
+                                                                                    </td>
+                                                                                    <td class="text-center p-1 align-middle text-nowrap">
+                                                                                        <b id="{{ $inv['name'].'-'.$item['item_code'] }}-qty">{!! $item['opening_stock'] !!}<br></b>
                                                                                         @if ($inv['status'] == 'Approved')
-                                                                                            <th class="text-center">-</th>
+                                                                                            <input id="{{ $inv['name'].'-'.$item['item_code'] }}-new-qty" type="text" class="form-control text-center d-none" name="item[{{ $item['item_code'] }}][qty]" value={{ $item['opening_stock'] }} style="font-size: 10pt;"/>
                                                                                         @endif
-                                                                                    </tr>
-                                                                                    @forelse ($inv['items'] as $item)
-                                                                                        @php
-                                                                                            $img = $item['image'] ? "/img/" . $item['image'] : "/icon/no_img.png";
-                                                                                            $img_webp = $item['image'] ? "/img/" . explode('.', $item['image'])[0].'.webp' : "/icon/no_img.webp";
-                                                                                        @endphp
-                                                                                        <tr>
-                                                                                            <td class="text-center p-0" style="font-size: 10pt">
-                                                                                                <div class="row p-0">
-                                                                                                    <div class="col-6 col-xl-2">
-                                                                                                        <picture>
-                                                                                                            <source srcset="{{ asset('storage'.$img_webp) }}" type="image/webp">
-                                                                                                            <source srcset="{{ asset('storage'.$img) }}" type="image/jpeg">
-                                                                                                            <img src="{{ asset('storage'.$img) }}" alt="{{ str_slug(explode('.', $img)[0], '-') }}" class="img-thumbna1il" width="100%">
-                                                                                                        </picture>
-                                                                                                    </div>
-                                                                                                    <div class="col-6 col-xl-10 item-code-container">
-                                                                                                        <b >{!! ''.$item['item_code'] !!}</b><span class="d-none d-xl-inline"> - {{ strip_tags($item['item_description']) }}</span>
-                                                                                                    </div>
-                                                                                                </div>
-                                                                                            </td>
-                                                                                            <td class="text-center" style="font-size: 10pt;">
-                                                                                                <b id="{{ $inv['name'].'-'.$item['item_code'] }}-qty">{!! $item['opening_stock'] !!}<br></b>
-                                                                                                @if ($inv['status'] == 'Approved')
-                                                                                                    <input id="{{ $inv['name'].'-'.$item['item_code'] }}-new-qty" type="text" class="form-control text-center d-none" name="item[{{ $item['item_code'] }}][qty]" value={{ $item['opening_stock'] }} style="font-size: 10pt;"/>
-                                                                                                @endif
-                                                                                                <small>{{ $item['uom'] }}</small>
-                                                                                            </td>
-                                                                                            <td class="text-center" style="font-size: 10pt; white-space: nowrap">
-                                                                                                @if (Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval')
-                                                                                                    ₱ <input type="text" name="price[{{ $item['item_code'] }}][]" value="{{ number_format($item['price'], 2) }}" style="text-align: center; width: 60px" required/>
-                                                                                                @else
-                                                                                                    ₱ {{ number_format($item['price'], 2) }}
-                                                                                                @endif
-                                                                                            </td>
-                                                                                            @if ($inv['status'] == 'Approved')
-                                                                                                <td class="text-center">
-                                                                                                    <span class="btn btn-primary btn-xs edit-stock_qty" data-reference="{{ $inv['name'].'-'.$item['item_code'] }}" data-name="{{ $inv['name'] }}"><i class="fa fa-edit"></i></span>
-                                                                                                </td>
-                                                                                            @endif
-                                                                                        </tr>
-                                                                                        <tr class="d-xl-none">
-                                                                                            <td colspan=4 class="text-justify p-2">
-                                                                                                <div class="w-100 item-description">
-                                                                                                    {{ strip_tags($item['item_description']) }}
-                                                                                                </div>
-                                                                                            </td>
-                                                                                        </tr>
-                                                                                    @empty
-                                                                                        <tr>
-                                                                                            <td class="text-center" colspan=4>No Item(s)</td>
-                                                                                        </tr>
-                                                                                    @endforelse
-                                                                                </table>
-                                                                            </div>
-                                                                            {{-- Update button for approved records --}}
-                                                                            @if ($inv['status'] == 'Approved')
-                                                                                <div class="modal-footer" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
-                                                                                    <button type="submit" class="btn btn-info w-100">Update</button>
-                                                                                </div>
-                                                                            @endif
-                                                                        </form>
+                                                                                        <small>{{ $item['uom'] }}</small>
+                                                                                    </td>
+                                                                                    <td class="text-center p-1 align-middle">
+                                                                                        @if (Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval')
+                                                                                            ₱ <input type="text" name="price[{{ $item['item_code'] }}][]" value="{{ number_format($item['price'], 2) }}" style="text-align: center; width: 60px" required/>
+                                                                                        @else
+                                                                                            ₱ {{ number_format($item['price'], 2) }}
+                                                                                        @endif
+                                                                                    </td>
+                                                                                    @if ($inv['status'] == 'Approved')
+                                                                                        <td class="text-center p-1 align-middle">
+                                                                                            <span class="btn btn-primary btn-xs edit-stock_qty" data-reference="{{ $inv['name'].'-'.$item['item_code'] }}" data-name="{{ $inv['name'] }}"><i class="fa fa-edit"></i></span>
+                                                                                        </td>
+                                                                                    @endif
+                                                                                </tr>
+                                                                                <tr class="d-xl-none">
+                                                                                    <td colspan="4" class="text-justify pt-0 pb-1 pl-1 pr-1" style="border-top: 0 !important;">
+                                                                                        <div class="w-100 item-description">{!! strip_tags($item['item_description']) !!}</div>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            @empty
+                                                                            <tr>
+                                                                                <td class="text-center text-uppercase text-muted" colspan="4">No Item(s)</td>
+                                                                            </tr>
+                                                                            @endforelse
+                                                                        </table>
                                                                     </div>
-                                                                </div>
+                                                                    {{-- Update button for approved records --}}
+                                                                    @if ($inv['status'] == 'Approved')
+                                                                    <div class="modal-footer" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
+                                                                        <button type="submit" class="btn btn-info w-100">Update</button>
+                                                                    </div>
+                                                                    @endif
+                                                                </form>
                                                             </div>
-                                                        </td>
-                                                    </tr>
-                                                @empty
-                                                    <tr>
-                                                        <td class="font-responsive text-center" colspan=7>
-                                                            No submitted beginning inventory
-                                                        </td>
-                                                    </tr>
-                                                @endforelse
-                                            </table>
-                                            <div class="float-right mt-4">
-                                                {{ $beginning_inventory->links('pagination::bootstrap-4') }}
-                                            </div>
-                                        </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        @empty
+                                            <tr>
+                                                <td class="font-responsive text-center text-muted text-uppercase p-2" colspan="7">
+                                                    No submitted beginning inventory
+                                                </td>
+                                            </tr>
+                                        @endforelse
+                                    </table>
+                                    <div class="float-right mt-4">
+                                        {{ $beginning_inventory->links('pagination::bootstrap-4') }}
                                     </div>
                                 </div>
                                 <div class="tab-pane fade" id="inventory-audit-history-content" role="tabpanel" aria-labelledby="inventory-audit-history-tab">

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -315,59 +315,59 @@
                                                                                             </button>
                                                                                         </div>
                                                                                         <div class="modal-body">
-                                                                                            <div class="callout callout-danger text-justify">
-                                                                                                <i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
-                                                                                            </div>
-                                                                                            <div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
-                                                                                                <table class="table">
-                                                                                                    <tr>
-                                                                                                        <th class="text-center" style='width: 60%;'>Item</th>
-                                                                                                        <th class="text-center" style="width: 20%;">Qty</th>
-                                                                                                        <th class="text-center" style="width: 20%;">Amount</th>
-                                                                                                    </tr>
-                                                                                                    @forelse($inv['sold'] as $item)
+                                                                                            @if ($inv['sold'])
+                                                                                                <div class="callout callout-danger text-justify">
+                                                                                                    <i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
+                                                                                                </div>
+                                                                                                <div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
+                                                                                                    <table class="table">
                                                                                                         <tr>
-                                                                                                            <td class="p-0" colspan=3>
-                                                                                                                <div class="p-0 row">
-                                                                                                                    <div class="col-6">
-                                                                                                                        <div class="row">
-                                                                                                                            <div class="col-4">
-                                                                                                                                <picture>
-                                                                                                                                    <source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
-                                                                                                                                    <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
-                                                                                                                                    <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
-                                                                                                                                </picture>
-                                                                                                                            </div>
-                                                                                                                            <div class="col-8" style="display: flex; justify-content: center; align-items: center;">
-                                                                                                                                <b>{{ $item['item_code'] }}</b>
+                                                                                                            <th class="text-center" style='width: 60%;'>Item</th>
+                                                                                                            <th class="text-center" style="width: 20%;">Qty</th>
+                                                                                                            <th class="text-center" style="width: 20%;">Amount</th>
+                                                                                                        </tr>
+                                                                                                        @foreach($inv['sold'] as $item)
+                                                                                                            <tr>
+                                                                                                                <td class="p-0" colspan=3>
+                                                                                                                    <div class="p-0 row">
+                                                                                                                        <div class="col-6">
+                                                                                                                            <div class="row">
+                                                                                                                                <div class="col-4">
+                                                                                                                                    <picture>
+                                                                                                                                        <source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
+                                                                                                                                        <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
+                                                                                                                                        <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+                                                                                                                                    </picture>
+                                                                                                                                </div>
+                                                                                                                                <div class="col-8" style="display: flex; justify-content: center; align-items: center;">
+                                                                                                                                    <b>{{ $item['item_code'] }}</b>
+                                                                                                                                </div>
                                                                                                                             </div>
                                                                                                                         </div>
+                                                                                                                        <div class="col-3 pt-2">
+                                                                                                                            <b>{{ number_format($item['qty']) }}</b> <br>
+                                                                                                                            <small>{{ $item['uom'] }}</small>
+                                                                                                                        </div>
+                                                                                                                        <div class="col-3" style="display: flex; justify-content: center; align-items: center;">
+                                                                                                                            ₱ {{ number_format($item['price'], 2) }}
+                                                                                                                        </div>
                                                                                                                     </div>
-                                                                                                                    <div class="col-3 pt-2">
-                                                                                                                        <b>{{ number_format($item['qty']) }}</b> <br>
-                                                                                                                        <small>{{ $item['uom'] }}</small>
+                                                                                                                    <div class="text-justify item-description">
+                                                                                                                        {{ $item['description'] }}
                                                                                                                     </div>
-                                                                                                                    <div class="col-3" style="display: flex; justify-content: center; align-items: center;">
-                                                                                                                        ₱ {{ number_format($item['price'], 2) }}
+                                                                                                                    <div class="text-justify pt-1 pb-2">
+                                                                                                                        <b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
                                                                                                                     </div>
-                                                                                                                </div>
-                                                                                                                <div class="text-justify item-description">
-                                                                                                                    {{ $item['description'] }}
-                                                                                                                </div>
-                                                                                                                <div class="text-justify pt-1 pb-2">
-                                                                                                                    <b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
-                                                                                                                </div>
-                                                                                                            </td>
-                                                                                                        </tr>
-                                                                                                    @empty
-                                                                                                        <tr>
-                                                                                                            <td class='text-center' colspan=3>
-                                                                                                                No record(s) found.
-                                                                                                            </td>
-                                                                                                        </tr>
-                                                                                                    @endforelse
-                                                                                                </table>
-                                                                                            </div>
+                                                                                                                </td>
+                                                                                                            </tr>
+                                                                                                        @endforeach
+                                                                                                    </table>
+                                                                                                </div>
+                                                                                            @else
+                                                                                                <div class="callout callout-danger text-justify">
+                                                                                                    <i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records.
+                                                                                                </div>
+                                                                                            @endif
                                                                                         </div>
                                                                                         <div class="modal-footer">
                                                                                             <a href="/cancel/approved_beginning_inv/{{ $inv['name'] }}" class="btn btn-primary w-100">Confirm</a>

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -109,7 +109,7 @@
                                                 }else if($inv['status'] == 'Approved'){
                                                     $badge = 'success';
                                                 }else if($inv['status'] == 'Cancelled'){
-                                                    $badge = 'danger';
+                                                    $badge = 'secondary';
                                                 }
 
                                                 $modal_form = Auth::user()->user_group == 'Consignment Supervisor' && $inv['status'] == 'For Approval' ? '/approve_beginning_inv/'.$inv['name'] : '/stock_adjust/submit/'.$inv['name'];
@@ -295,8 +295,87 @@
                                                                     </div>
                                                                     {{-- Update button for approved records --}}
                                                                     @if ($inv['status'] == 'Approved')
-                                                                    <div class="modal-footer" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
-                                                                        <button type="submit" class="btn btn-info w-100">Update</button>
+                                                                    <div class="modal-footer">
+                                                                        <div class="container-fluid" id="{{ $inv['name'] }}-stock-adjust-update-btn" style="display: none">
+                                                                            <button type="submit" class="btn btn-info w-100">Update</button>
+                                                                        </div>
+                                                                        <div class="container-fluid">
+                                                                            <button type="button" class="btn btn-secondary w-100" data-toggle="modal" data-target="#cancel-{{ $inv['name'] }}-Modal">
+                                                                                Cancel
+                                                                            </button>
+                                                                            
+                                                                            <!-- Modal -->
+                                                                            <div class="modal fade" id="cancel-{{ $inv['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                                                <div class="modal-dialog" role="document">
+                                                                                    <div class="modal-content">
+                                                                                        <div class="modal-header bg-navy">
+                                                                                            <h6 id="exampleModalLabel">Cancel Beginning Inventory?</h6>
+                                                                                            <button type="button" class="close">
+                                                                                            <span aria-hidden="true" style="color: #fff" onclick="close_modal('#cancel-{{ $inv['name'] }}-Modal')">&times;</span>
+                                                                                            </button>
+                                                                                        </div>
+                                                                                        <div class="modal-body">
+                                                                                            <div class="callout callout-danger text-justify">
+                                                                                                <i class="fas fa-info-circle"></i> Canceling beginnning inventory record will also cancel submitted product sold records of the following:
+                                                                                            </div>
+                                                                                            <div class="container-fluid" id="cancel-{{ $inv['name'] }}-container">
+                                                                                                <table class="table">
+                                                                                                    <tr>
+                                                                                                        <th class="text-center" style='width: 60%;'>Item</th>
+                                                                                                        <th class="text-center" style="width: 20%;">Qty</th>
+                                                                                                        <th class="text-center" style="width: 20%;">Amount</th>
+                                                                                                    </tr>
+                                                                                                    @forelse($inv['sold'] as $item)
+                                                                                                        <tr>
+                                                                                                            <td class="p-0" colspan=3>
+                                                                                                                <div class="p-0 row">
+                                                                                                                    <div class="col-6">
+                                                                                                                        <div class="row">
+                                                                                                                            <div class="col-4">
+                                                                                                                                <picture>
+                                                                                                                                    <source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp">
+                                                                                                                                    <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
+                                                                                                                                    <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="40" height="40">
+                                                                                                                                </picture>
+                                                                                                                            </div>
+                                                                                                                            <div class="col-8" style="display: flex; justify-content: center; align-items: center;">
+                                                                                                                                <b>{{ $item['item_code'] }}</b>
+                                                                                                                            </div>
+                                                                                                                        </div>
+                                                                                                                    </div>
+                                                                                                                    <div class="col-3 pt-2">
+                                                                                                                        <b>{{ number_format($item['qty']) }}</b> <br>
+                                                                                                                        <small>{{ $item['uom'] }}</small>
+                                                                                                                    </div>
+                                                                                                                    <div class="col-3" style="display: flex; justify-content: center; align-items: center;">
+                                                                                                                        ₱ {{ number_format($item['price'], 2) }}
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                                <div class="text-justify item-description">
+                                                                                                                    {{ $item['description'] }}
+                                                                                                                </div>
+                                                                                                                <div class="text-justify pt-1 pb-2">
+                                                                                                                    <b>Transaction Date:</b>&nbsp;{{ Carbon\Carbon::parse($item['date'])->format('F d, Y') }}
+                                                                                                                </div>
+                                                                                                            </td>
+                                                                                                        </tr>
+                                                                                                    @empty
+                                                                                                        <tr>
+                                                                                                            <td class='text-center' colspan=3>
+                                                                                                                No record(s) found.
+                                                                                                            </td>
+                                                                                                        </tr>
+                                                                                                    @endforelse
+                                                                                                </table>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                        <div class="modal-footer">
+                                                                                            <a href="/cancel/approved_beginning_inv/{{ $inv['name'] }}" class="btn btn-primary w-100">Confirm</a>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
                                                                     </div>
                                                                     @endif
                                                                 </form>
@@ -344,6 +423,9 @@
         .item-code-container{
             text-align: justify;
             padding: 10px;
+        }
+        .modal{
+            background-color: rgba(0,0,0,0.4);
         }
         @media (max-width: 575.98px) {
             .last-row{

--- a/resources/views/consignment/view_damaged_items_list.blade.php
+++ b/resources/views/consignment/view_damaged_items_list.blade.php
@@ -6,9 +6,9 @@
 @section('content')
 <div class="content">
 	<div class="content-header p-0">
-        <div class="container-fluid p-0">
-            <div class="row mt-1">
-                <div class="col-md-9 mx-auto">
+        <div class="container">
+            <div class="row pt-1">
+                <div class="col-md-12 p-0 m-0">
                     <div class="row">
                         <div class="col-3">
                             <div style="margin-bottom: -43px;">
@@ -19,277 +19,313 @@
                             <h4 class="text-center font-weight-bold m-2 text-uppercase">Stock Transfers</h4>
                         </div>
                     </div>
-                    <div class="card card-info card-outline">
+                    <div class="card card-secondary card-outline">
                         <div class="card-body p-2">
                             <ul class="nav nav-pills m-0" role="tablist">
                                 <li class="nav-item">
-                                    <a class="nav-link active font-responsive" data-toggle="tab" href="#stock_transfers">Stock Transfers</a>
+                                    <a class="nav-link active font-responsive" data-toggle="tab" href="#stock_transfers">Stock Transfer History</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link font-responsive" data-toggle="tab" href="#damaged_items">Damaged Items</a>
+                                    <a class="nav-link font-responsive" data-toggle="tab" href="#damaged_items">Damaged Item List</a>
                                 </li>
                             </ul>
-
-                             <!-- Tab panes -->
-                        <div class="tab-content">
-                            <!-- Stock Transfers -->
-                            <div id="stock_transfers" class="container-fluid tab-pane active" style="padding: 8px 0 0 0;">
-                                <div id="accordion" class="p-0 m-0" style="border: none !important">
-                                    <div class="p-0 m-0" style="border: none !important">
-                                        <div class="card-header p-2 d-block d-xl-none" id="headingOne">
-                                            <button class="btn btn-link p-0" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne" style="font-size: 10pt">
-                                                <i class="fa fa-filter"></i>&nbsp;Filters
+                            
+                            <div class="tab-content">
+                                <div id="stock_transfers" class="tab-pane active">
+                                    <!-- Stock Transfers -->
+                                    <form action="/stocks_report/list" method="get">
+                                        <div id="accordion" class="mt-2">
+                                            <button type="button" class="btn btn-link border-bottom btn-block text-left d-xl-none d-lg-none" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne" style="font-size: 10pt;">
+                                                <i class="fa fa-filter"></i> Filters
                                             </button>
-                                        </div>
-                                    
-                                        <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordion">
-                                            <div class="card-body">
-                                                <form action="/stocks_report/list" method="get">
-                                                    <div class="row">
-                                                        <div class="col-12 col-xl-2">
-                                                            <input type="text" name="tab1_q" class="form-control" placeholder='Search' style='font-size: 10pt'/>
-                                                        </div>
-                                                        <div class="col-12 mt-2 mt-xl-0 col-xl-2">
-                                                            <select name="source_warehouse" id="source-warehouse" class="form-control" style="font-size: 10pt"></select>
-                                                        </div>
-                                                        <div class="col-12 mt-2 mt-xl-0 col-xl-2">
-                                                            <select name="target_warehouse" id="target-warehouse" class="form-control" style="font-size: 10pt"></select>
-                                                        </div>
-                                                        <div class="col-12 mt-2 mt-xl-0 col-xl-2">
-                                                            <select name="tab1_status" id='status' class="form-control" style="font-size: 10pt">
-                                                                @php
-                                                                    $status = [
-                                                                        ['title' => 'Select All', 'value' => 'All'],
-                                                                        ['title' => 'For Approval', 'value' => 0],
-                                                                        ['title' => 'Approved', 'value' => 1]
-                                                                    ];
-                                                                @endphp 
-                                                                <option value="" disabled selected>Select a status</option>
-                                                                @foreach ($status as $s)
-                                                                    <option value="{{ $s['value'] }}">{{ $s['title'] }}</option>
-                                                                @endforeach
-                                                            </select>
-                                                        </div>
-                                                        <div class="col-12 col-xl-1 mt-2 mt-xl-0">
-                                                            <button type="submit" class="btn btn-primary w-100"><i class="fas fa-search"></i></button>
-                                                        </div>
+                                            <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordion">
+                                                <div class="row p-2">
+                                                    <div class="col-12 col-xl-2 col-lg-2">
+                                                        <input type="text" name="tab1_q" class="form-control" placeholder='Search' style='font-size: 10pt;'/>
                                                     </div>
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <table class="table table-striped table-bordered" style="font-size: 10pt;">
-                                    <thead>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" id='first-row'>Date</th>
-                                        <th class="text-center p-2 align-middle text-uppercase" id='second-row'>
-                                            <span class="d-block d-xl-none">Details</span>
-                                            <span class="d-none d-xl-block">Name</span>
-                                        </th>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" style="width: 10%">Purpose</th>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" style="width: 20%">From</th>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" style="width: 20%">To</th>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" style="width: 10%">Created by</th>
-                                        <th class="text-center p-2 align-middle text-uppercase d-none d-xl-table-cell" style="width: 10%">Status</th>
-                                        <th class="text-center p-2 align-middle text-uppercase" style="width: 10%">Action</th>
-                                    </thead>
-                                    <tbody>
-                                        @forelse ($ste_arr as $ste)
-                                        @php
-                                            if($ste['status'] == 'Approved'){
-                                                $badge = 'success';
-                                            }else{
-                                                $badge = 'primary';
-                                            }
-                                        @endphp
-                                        <tr>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">{{ $ste['creation'] }}</td>
-                                            <td class="text-center p-1 align-middle">
-                                                {{ $ste['name'] }}
-                                                <div class="d-block d-xl-none text-left">
-                                                    <b>From: </b> {{ $ste['source_warehouse'] }} <br>
-                                                    <b>To: </b> {{ $ste['target_warehouse'] }} <br>
-                                                    <b>Purpose: </b> {{ $ste['transfer_as'] }} <br>
-                                                    <b>Date: </b> {{ $ste['creation'] }}
-                                                </div>
-                                            </td>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">{{ $ste['transfer_as'] }}</td>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">{{ $ste['source_warehouse'] }}</td>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">{{ $ste['target_warehouse'] }}</td>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">{{ $ste['submitted_by'] }}</td>
-                                            <td class="text-center p-1 align-middle d-none d-xl-table-cell">
-                                                <span class="badge badge-{{ $badge }}">{{ $ste['status'] }}</span>
-                                            </td>
-                                            <td class="text-center p-1 align-middle">
-                                                <a href="#" data-toggle="modal" data-target="#{{ $ste['name'] }}-Modal" style="font-size: 10pt;">
-                                                    View Items
-                                                </a>
-                                                <span class="badge badge-{{ $badge }} d-xl-none">{{ $ste['status'] }}</span>
-                                                <!-- Modal -->
-                                                <div class="modal fade" id="{{ $ste['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                                                    <div class="modal-dialog" role="document">
-                                                        <div class="modal-content">
-                                                            <div class="modal-header" style="background-color: #001F3F; color: #fff">
-                                                                <div class="row text-left">
-                                                                    <div class="col-12">
-                                                                        <h5 id="exampleModalLabel"><b>{{ $ste['name'] }}</b></h5>
-                                                                    </div>
-                                                                    <div class="col-12" style="font-size: 8pt;">
-                                                                        <span class="font-italic"><b>Source: </b> {{ $ste['source_warehouse'] }}</span>
-                                                                    </div>
-                                                                    <div class="col-12" style="font-size: 8pt;">
-                                                                        <span class="font-italic"><b>Target: </b> {{ $ste['target_warehouse'] }}</span>
-                                                                    </div>
-                                                                </div>
-                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                                <span aria-hidden="true" style="color: #fff">&times;</span>
-                                                                </button>
-                                                            </div>
-                                                            <div class="modal-body">
-                                                                <table class="table table-bordered">
-                                                                    <tr>
-                                                                        <th class="text-center" width="50%">Item</th>
-                                                                        <th class="text-center">Stock Qty</th>
-                                                                        <th class="text-center">Qty to Transfer</th>
-                                                                    </tr>
-                                                                    @foreach ($ste['items'] as $item)
-                                                                        <tr>
-                                                                            <td class="text-center p-0">
-                                                                                <div class="row">
-                                                                                    <div class="col-4">
-                                                                                        <picture>
-                                                                                            <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp">
-                                                                                            <source srcset="{{ asset('storage/'.$item['image']) }}" type="image/jpeg">
-                                                                                            <img src="{{ asset('storage/'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" class="w-100">
-                                                                                        </picture>
-                                                                                    </div>
-                                                                                    <div class="col-5" style="display: flex; justify-content: center; align-items: center;">
-                                                                                        <b>{{ $item['item_code'] }}</b>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </td>
-                                                                            <td class="text-center">
-                                                                                <b>{{ $item['consigned_qty'] * 1 }}</b><br/><small>{{ $item['uom'] }}</small>
-                                                                            </td>
-                                                                            <td class="text-center">
-                                                                                <b>{{ $item['transfer_qty'] * 1 }}</b><br/><small>{{ $item['uom'] }}</small>
-                                                                                </td>
-                                                                        </tr>
-                                                                        <tr class="p-2">
-                                                                            <td colspan=3 class="text-justify">
-                                                                                <div class="item-description">
-                                                                                    {{ strip_tags($item['description']) }}
-                                                                                </div>
-                                                                            </td>
-                                                                        </tr>
-                                                                    @endforeach
-                                                                </table>
-                                                            </div>
-                                                        </div>
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-3 col-lg-3">
+                                                        <select name="source_warehouse" id="source-warehouse" class="form-control" style="font-size: 10pt;"></select>
+                                                    </div>
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-3 col-lg-3">
+                                                        <select name="target_warehouse" id="target-warehouse" class="form-control" style="font-size: 10pt;"></select>
+                                                    </div>
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-2 col-lg-2">
+                                                        <select name="tab1_status" id='status' class="form-control" style="font-size: 10pt;">
+                                                            @php
+                                                                $status = [
+                                                                    ['title' => 'Select All', 'value' => 'All'],
+                                                                    ['title' => 'For Approval', 'value' => 0],
+                                                                    ['title' => 'Approved', 'value' => 1]
+                                                                ];
+                                                            @endphp 
+                                                            <option value="" disabled selected>Select a status</option>
+                                                            @foreach ($status as $s)
+                                                            <option value="{{ $s['value'] }}">{{ $s['title'] }}</option>
+                                                            @endforeach
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 col-xl-2 col-lg-2 mt-2 mt-lg-0">
+                                                        <button type="submit" class="btn btn-primary btn-block"><i class="fas fa-search"></i> Search</button>
                                                     </div>
                                                 </div>
-                                            </td>
-                                        </tr>
-                                        @empty
-                                        <tr>
-                                            <td colspan="7" class="text-center font-responsive text-uppercase text-muted p-2">No record(s) found</td>
-                                        </tr>
-                                        @endforelse
-                                    </tbody>
-                                </table>
-                                <div class="float-left m-2">Total: <b>{{ $stock_entry->total() }}</b></div>
-                                <div class="float-right m-2" id="beginning-inventory-list-pagination">{{ $stock_entry->links('pagination::bootstrap-4') }}</div>
-                            </div>
-                            <!-- Stock Transfers -->
-
-                            <!-- Damaged Items -->
-                            <div id="damaged_items" class="container-fluid tab-pane" style="padding: 8px 0 0 0;">
-                                <div id="accordion2" class="p-0 m-0" style="border: none !important">
-                                    <div class="card-header p-2 d-block d-xl-none border" id="headingOne">
-                                        <button class="btn btn-link p-0" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo" style="font-size: 10pt">
-                                            <i class="fa fa-filter"></i>&nbsp;Filters
-                                        </button>
-                                    </div>
-                                
-                                    <div id="collapseTwo" class="collapse" aria-labelledby="headingOne" data-parent="#accordion2">
-                                        <form action="/stocks_report/list" method="GET">
-                                            <div class="row p-1 mt-1 mb-1">
-                                                <div class="col-12 col-xl-3">
-                                                    <input type="text" name="search" class="form-control" value="{{ request('search') }}" placeholder="Search Item" style='font-size: 10pt'/>
-                                                </div>
-                                                <div class="col-12 mt-2 mt-xl-0 col-xl-3">
-                                                    @php
-                                                        $statuses = ['For Approval', 'Approved', 'Cancelled'];
-                                                    @endphp
-                                                    <select class="form-control" name="store" id="consignment-store-select">
-                                                        <option value="">Select Store</option>
-                                                        @foreach ($statuses as $status)
-                                                        <option value="{{ $status }}">{{ $status }}</option>
-                                                        @endforeach
-                                                    </select>
-                                                </div>
-                                                <div class="col-12 mt-2 mt-xl-0 col-xl-1">
-                                                    <button class="btn btn-primary w-100"><i class="fas fa-search"></i></button>
-                                                </div>
                                             </div>
-                                        </form>
-                                    </div>
-                                </div>
-                                <div class="card-body p-2">
-                                    <table class="table table-striped table-bordered" style="font-size: 10pt;">
+                                        </div>
+                                    </form>
+                                    <table class="table table-striped" style="font-size: 9pt;">
                                         <thead>
-                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%;">Date</th>
-                                            <th class="text-center p-2 align-middle" style="width: 35%;">Item Description</th>
-                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%;">Qty</th>
-                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%;">Store</th>
-                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%;">Damage Description</th>
-                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 5%;">-</th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" id='first-row'>Date</th>
+                                            <th class="text-center p-2 align-middle" id='second-row'>
+                                                <span class="d-block d-xl-none">Details</span>
+                                                <span class="d-none d-xl-block">Name</span>
+                                            </th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%">Purpose</th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%">From</th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%">To</th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%">Created by</th>
+                                            <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%">Status</th>
+                                            <th class="text-center p-2 align-middle" style="width: 10%">Action</th>
                                         </thead>
-                                        @forelse ($items_arr as $i => $item)
+                                        <tbody>
+                                            @forelse ($ste_arr as $ste)
+                                            @php
+                                                if($ste['status'] == 'Approved'){
+                                                    $badge = 'success';
+                                                }else{
+                                                    $badge = 'primary';
+                                                }
+                                            @endphp
                                             <tr>
-                                                <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['creation'] }}</td>
-                                                <td class="p-1 text-justify align-middle">
-                                                    <div class="d-flex flex-row align-items-center">
-                                                        <div class="p-1">
-                                                            <picture>
-                                                                <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp">
-                                                                <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
-                                                                <img src="{{ asset('storage/'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="70">
-                                                            </picture>
-                                                        </div>
-                                                        <div class="p-1">
-                                                            <span class="d-block font-weight-bold">{{ $item['item_code'] }}</span>
-                                                            <small class="d-block item-description">{!! strip_tags($item['description']) !!}</small>
-        
-                                                            <small class="d-block mt-2">Created by: <b>{{ $item['promodiser'] }}</b></small>
-                                                        </div>
-                                                    </div>
-                                                    <div class="d-block d-xl-none" style="font-size: 9pt;">
-                                                        <b>Damaged Qty: </b>{{ $item['damaged_qty'] }}&nbsp;<small>{{ $item['uom'] }}</small> <br>
-                                                        <b>Store: </b> {{ $item['store'] }} <br>
-                                                        <b>Damage Description: </b> {{ $item['damage_description'] }} <br>
-                                                        <b>Date: </b> {{ $item['creation'] }}
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">{{ $ste['creation'] }}</td>
+                                                <td class="text-center p-2 align-middle">
+                                                    <span class="d-block text-left text-lg-center text-xl-center font-weight-bold"> {{ $ste['name'] }}</span>
+                                                    <div class="d-block d-xl-none text-left">
+                                                        <b>From: </b> {{ $ste['source_warehouse'] }} <br>
+                                                        <b>To: </b> {{ $ste['target_warehouse'] }} <br>
+                                                        <b>Purpose: </b> {{ $ste['transfer_as'] }} <br>
+                                                        {{ $ste['submitted_by'] }} - {{ $ste['creation'] }}
                                                     </div>
                                                 </td>
-                                                <td class="p-1 text-center align-middle d-none d-xl-table-cell">
-                                                    <span class="d-block font-weight-bold">{{ $item['damaged_qty'] }}</span>
-                                                    <small>{{ $item['uom'] }}</small>
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">{{ $ste['transfer_as'] }}</td>
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">{{ $ste['source_warehouse'] }}</td>
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">{{ $ste['target_warehouse'] }}</td>
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">{{ $ste['submitted_by'] }}</td>
+                                                <td class="text-center p-2 align-middle d-none d-xl-table-cell">
+                                                    <span class="badge badge-{{ $badge }}">{{ $ste['status'] }}</span>
                                                 </td>
-                                                <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['store'] }}</td>
-                                                <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['damage_description'] }}</td>
-                                                <td class="p-1 text-center align-middle d-none d-xl-table-cell">
-                                                    <a href="#" class="btn btn-primary btn-sm"><i class="fas fa-retweet"></i></a>
+                                                <td class="text-center p-2 align-middle">
+                                                    <a href="#" data-toggle="modal" data-target="#{{ $ste['name'] }}-Modal" style="font-size: 10pt;" class="d-block">View Items</a>
+                                                    <span class="badge badge-{{ $badge }} d-xl-none">{{ $ste['status'] }}</span>
+                                                    <!-- Modal -->
+                                                    <div class="modal fade" id="{{ $ste['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                        <div class="modal-dialog modal-xl" role="document">
+                                                            <div class="modal-content">
+                                                                <div class="modal-header bg-navy">
+                                                                    <h6 class="modal-title">{{ $ste['name'] }} <span class="badge badge-{{ $badge }} d-inline-block ml-2">{{ $ste['status'] }}</span></h6>
+                                                                    <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
+                                                                        <span aria-hidden="true">&times;</span>
+                                                                    </button>
+                                                                </div>
+                                                                <div class="modal-body">
+                                                                    <div class="row pb-0 mb-3">
+                                                                        <div class="pt-0 pr-2 pl-2 pb-0 col-6 text-left m-0">
+                                                                            <dl class="row p-0 m-0">
+                                                                                <dt class="col-12 col-xl-3 col-lg-2 p-1 m-0">Source:</dt>
+                                                                                <dd class="col-12 col-xl-9 col-lg-10 p-1 m-0">{{ $ste['source_warehouse'] }}</dd>
+                                                                                <dt class="col-12 col-xl-3 col-lg-2 p-1 m-0">Target:</dt>
+                                                                                <dd class="col-12 col-xl-9 col-lg-10 p-1 m-0">{{ $ste['target_warehouse'] }}</dd>
+                                                                                <dt class="col-12 col-xl-3 col-lg-2 p-1 m-0">Transfer As:</dt>
+                                                                                <dd class="col-12 col-xl-9 col-lg-10 p-1 m-0">{{ $ste['transfer_as'] }}</dd>
+                                                                            </dl>
+                                                                        </div>
+                                                                        <div class="pt-0 pr-2 pl-2 pb-0 col-6 text-left m-0">
+                                                                            <dl class="row p-0 m-0">
+                                                                                <dt class="col-12 col-xl-4 col-lg-6 p-1 m-0">Transaction Date:</dt>
+                                                                                <dd class="col-12 col-xl-8 col-lg-6 p-1 m-0">{{ $ste['creation'] }}</dd>
+                                                                                <dt class="col-12 col-xl-4 col-lg-6 p-1 m-0">Submitted by:</dt>
+                                                                                <dd class="col-12 col-xl-8 col-lg-6 p-1 m-0">{{ $ste['submitted_by'] }}</dd>
+                                                                            </dl>   
+                                                                        </div>
+                                                                    </div>
+                                                                    <table class="table table-striped" style="font-size: 10pt;">
+                                                                        <thead>
+                                                                            <th class="text-center p-2 align-middle" width="50%">Item Code</th>
+                                                                            <th class="text-center p-2 align-middle">Stock Qty</th>
+                                                                            <th class="text-center p-2 align-middle">Qty to Transfer</th>
+                                                                        </thead>
+                                                                        @foreach ($ste['items'] as $item)
+                                                                            <tr>
+                                                                                <td class="text-center p-1 align-middle">
+                                                                                    <div class="d-flex flex-row justify-content-start align-items-center">
+                                                                                        <div class="p-2 text-left">
+                                                                                            <a href="{{ asset('storage/') }}{{ $item['image'] }}" data-toggle="mobile-lightbox" data-gallery="{{ $item['item_code'] }}" data-title="{{ $item['item_code'] }}">
+                                                                                                <picture>
+                                                                                                    <source srcset="{{ asset('storage'.$item['webp']) }}" type="image/webp" width="60" height="60">
+                                                                                                    <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg" width="60" height="60">
+                                                                                                    <img src="{{ asset('storage'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="60" height="60">
+                                                                                                </picture>
+                                                                                            </a>
+                                                                                        </div>
+                                                                                        <div class="p-2 text-left">
+                                                                                            <b>{!! ''.$item['item_code'] !!}</b>
+                                                                                            <span class="d-none d-xl-inline"> - {!! strip_tags($item['description']) !!}</span>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div class="modal fade" id="mobile-{{ $item['item_code'] }}-images-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                                                                                        <div class="modal-dialog modal-dialog-centered" role="document">
+                                                                                            <div class="modal-content">
+                                                                                                <div class="modal-header">
+                                                                                                    <h5 class="modal-title">{{ $item['item_code'] }}</h5>
+                                                                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                                                        <span aria-hidden="true">&times;</span>
+                                                                                                    </button>
+                                                                                                </div>
+                                                                                                <div class="modal-body">
+                                                                                                    <form></form>
+                                                                                                    <div class="container-fluid">
+                                                                                                        <div id="carouselExampleControls" class="carousel slide" data-interval="false">
+                                                                                                            <div class="carousel-inner">
+                                                                                                                <div class="carousel-item active">
+                                                                                                                    <picture>
+                                                                                                                        <source id="mobile-{{ $item['item_code'] }}-webp-image-src" srcset="{{ asset('storage/').$item['webp'] }}" type="image/webp" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                        <source id="mobile-{{ $item['item_code'] }}-orig-image-src" srcset="{{ asset('storage/').$item['image'] }}" type="image/jpeg" class="d-block w-100" style="width: 100% !important;">
+                                                                                                                        <img class="d-block w-100" id="mobile-{{ $item['item_code'] }}-image" src="{{ asset('storage/').$item['image'] }}" alt="{{ Illuminate\Support\Str::slug(explode('.', $item['image'])[0], '-') }}">
+                                                                                                                    </picture>
+                                                                                                                </div>
+                                                                                                                <span class='d-none' id="mobile-{{ $item['item_code'] }}-image-data">0</span>
+                                                                                                            </div>
+                                                                                                            <a class="carousel-control-prev" href="#carouselExampleControls" onclick="prevImg('{{ $item['item_code'] }}')" role="button" data-slide="prev" style="color: #000 !important">
+                                                                                                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                                                                                                <span class="sr-only">Previous</span>
+                                                                                                            </a>
+                                                                                                            <a class="carousel-control-next" href="#carouselExampleControls" onclick="nextImg('{{ $item['item_code'] }}')" role="button" data-slide="next" style="color: #000 !important">
+                                                                                                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                                                                                                <span class="sr-only">Next</span>
+                                                                                                            </a>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </td>
+                                                                                <td class="text-center p-1 align-middle">
+                                                                                    <b>{{ $item['consigned_qty'] * 1 }}</b><br/><small>{{ $item['uom'] }}</small>
+                                                                                </td>
+                                                                                <td class="text-center p-1 align-middle">
+                                                                                    <b>{{ $item['transfer_qty'] * 1 }}</b><br/><small>{{ $item['uom'] }}</small>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr class="d-xl-none">
+                                                                                <td colspan="3" class="text-justify pt-0 pb-1 pl-1 pr-1" style="border-top: 0 !important;">
+                                                                                    <div class="w-100 item-description">{!! strip_tags($item['description']) !!}</div>
+                                                                                </td>
+                                                                            </tr>
+                                                                        @endforeach
+                                                                    </table>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
                                                 </td>
                                             </tr>
                                             @empty
                                             <tr>
-                                                <td colspan="6" class="text-center">No record(s) found.</td>
+                                                <td colspan="7" class="text-center font-responsive text-uppercase text-muted p-2">No record(s) found</td>
                                             </tr>
-                                        @endforelse
+                                            @endforelse
+                                        </tbody>
                                     </table>
-                                    <div class="float-left m-2">Total: <b>{{ $damaged_items->total() }}</b></div>
-                                    <div class="float-right m-2" id="beginning-inventory-list-pagination">{{ $damaged_items->links('pagination::bootstrap-4') }}</div>
+                                    <div class="float-left m-2">Total: <b>{{ $stock_entry->total() }}</b></div>
+                                    <div class="float-right m-2" id="beginning-inventory-list-pagination">{{ $stock_entry->links('pagination::bootstrap-4') }}</div>
                                 </div>
+                                <!-- Stock Transfers -->
+
+                            <!-- Damaged Items -->
+                            <div id="damaged_items" class="tab-pane">
+                                <form action="/stocks_report/list" method="GET">
+                                    <div id="accordion2" class="mt-2">
+                                        <button type="button" class="btn btn-link border-bottom btn-block text-left d-xl-none d-lg-none" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo" style="font-size: 10pt;">
+                                            <i class="fa fa-filter"></i> Filters
+                                        </button>
+                                    </div>
+                                    
+                                    <div id="collapseTwo" class="collapse" aria-labelledby="headingOne" data-parent="#accordion2">
+                                        <div class="row p-2">
+                                            <div class="col-12 col-xl-4 col-lg-4 mt-2 mt-lg-0">
+                                                <input type="text" name="search" class="form-control" value="{{ request('search') }}" placeholder="Search Item" style='font-size: 10pt'/>
+                                            </div>
+                                            <div class="col-12 col-xl-4 col-lg-4 mt-2 mt-lg-0">
+                                                @php
+                                                    $statuses = ['For Approval', 'Approved', 'Cancelled'];
+                                                @endphp
+                                                <select class="form-control" name="store" id="consignment-store-select">
+                                                    <option value="">Select Store</option>
+                                                    @foreach ($statuses as $status)
+                                                    <option value="{{ $status }}">{{ $status }}</option>
+                                                    @endforeach
+                                                </select>
+                                            </div>
+                                            <div class="col-12 col-xl-2 col-lg-2 mt-2 mt-lg-0">
+                                                <button class="btn btn-primary btn-block"><i class="fas fa-search"></i> Search</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </form>
+
+                                <table class="table table-striped" style="font-size: 9pt;">
+                                    <thead>
+                                        <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%;">Date</th>
+                                        <th class="text-center p-2 align-middle" style="width: 35%;">Item Description</th>
+                                        <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 10%;">Qty</th>
+                                        <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%;">Store</th>
+                                        <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 20%;">Damage Description</th>
+                                        <th class="text-center p-2 align-middle d-none d-xl-table-cell" style="width: 5%;">-</th>
+                                    </thead>
+                                    @forelse ($items_arr as $i => $item)
+                                        <tr>
+                                            <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['creation'] }}</td>
+                                            <td class="p-1 text-justify align-middle">
+                                                <div class="d-flex flex-row align-items-center">
+                                                    <div class="p-1">
+                                                        <picture>
+                                                            <source srcset="{{ asset('storage/'.$item['webp']) }}" type="image/webp">
+                                                            <source srcset="{{ asset('storage'.$item['image']) }}" type="image/jpeg">
+                                                            <img src="{{ asset('storage/'.$item['image']) }}" alt="{{ str_slug(explode('.', $item['image'])[0], '-') }}" width="70">
+                                                        </picture>
+                                                    </div>
+                                                    <div class="p-1">
+                                                        <span class="d-block font-weight-bold">{{ $item['item_code'] }}</span>
+                                                        <small class="d-block item-description">{!! strip_tags($item['description']) !!}</small>
+    
+                                                        <small class="d-block mt-2">Created by: <b>{{ $item['promodiser'] }}</b></small>
+                                                    </div>
+                                                </div>
+                                                <div class="d-block d-xl-none" style="font-size: 9pt;">
+                                                    <b>Damaged Qty: </b>{{ $item['damaged_qty'] }}&nbsp;<small>{{ $item['uom'] }}</small> <br>
+                                                    <b>Store: </b> {{ $item['store'] }} <br>
+                                                    <b>Damage Description: </b> {{ $item['damage_description'] }} <br>
+                                                    <b>Date: </b> {{ $item['creation'] }}
+                                                </div>
+                                            </td>
+                                            <td class="p-1 text-center align-middle d-none d-xl-table-cell">
+                                                <span class="d-block font-weight-bold">{{ $item['damaged_qty'] }}</span>
+                                                <small>{{ $item['uom'] }}</small>
+                                            </td>
+                                            <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['store'] }}</td>
+                                            <td class="p-1 text-center align-middle d-none d-xl-table-cell">{{ $item['damage_description'] }}</td>
+                                            <td class="p-1 text-center align-middle d-none d-xl-table-cell">
+                                                <a href="#" class="btn btn-primary btn-sm"><i class="fas fa-retweet"></i></a>
+                                            </td>
+                                        </tr>
+                                        @empty
+                                        <tr>
+                                            <td colspan="6" class="text-center">No record(s) found.</td>
+                                        </tr>
+                                    @endforelse
+                                </table>
+                                <div class="float-left m-2">Total: <b>{{ $damaged_items->total() }}</b></div>
+                                <div class="float-right m-2" id="beginning-inventory-list-pagination">{{ $damaged_items->links('pagination::bootstrap-4') }}</div>
+                             
                             </div>
                             <!-- Damaged Items -->
                         </div>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -2163,11 +2163,6 @@
 				}
 			});
 		}
-
-		function close_modal(modal){
-			$('#'+modal).modal('hide');
-		}
-		
 	</script>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -152,6 +152,7 @@ Route::group(['middleware' => 'auth'], function(){
     Route::get('/beginning_inventory/{inv?}', 'ConsignmentController@beginningInventory');
     Route::get('/beginning_inv_items/{action}/{branch}/{id?}', 'ConsignmentController@beginningInvItems');
     Route::get('/get_items/{branch}', 'ConsignmentController@getItems');
+    Route::get('/cancel/approved_beginning_inv/{id}', 'ConsignmentController@cancelApprovedBeginningInventory');
     Route::post('/save_beginning_inventory', 'ConsignmentController@saveBeginningInventory');
     Route::get('/promodiser/delivery_report/{type}', 'ConsignmentController@promodiserDeliveryReport');
     Route::get('/promodiser/receive/{id}', 'ConsignmentController@promodiserReceiveDelivery');


### PR DESCRIPTION
# Release notes - AthenaERP Inventory - Version Version 5.1

### Story

[AI-331](https://fumacoinc.atlassian.net/browse/AI-331) In inventory audit list, include total qty sold, promodiser name, and transaction date for consignment supervisor

[AI-329](https://fumacoinc.atlassian.net/browse/AI-329) Cancellation of Beggining Inventory for Consigment Supervisor

[AI-328](https://fumacoinc.atlassian.net/browse/AI-328) Cancellation of Beggining Inventory once Approved for promodisers

[AI-321](https://fumacoinc.atlassian.net/browse/AI-321) in Stock adjustment list, include total value and qty in display for consignment supervisor

[AI-307](https://fumacoinc.atlassian.net/browse/AI-307) Unify modal design and tables for all add items form for promodisers

[AI-306](https://fumacoinc.atlassian.net/browse/AI-306) in Stock adjustment list, include total value and qty in display for promodiser

[AI-304](https://fumacoinc.atlassian.net/browse/AI-304) Classify stock adjustment type in beginning inventory form for promodisers