### PR TITLE
Version 5.3

### DIFF
--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -308,8 +308,8 @@ class ConsignmentController extends Controller
         $item_images = DB::table('tabItem Images')->whereIn('parent', $item_codes)->select('parent', 'image_path')->orderBy('idx', 'asc')->get();
         $item_images = collect($item_images)->groupBy('parent')->toArray();
 
-        $existing_record = DB::table('tabConsignment Sales Report as csr')->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')->where('csr.branch_warehouse', $branch)
-            ->where('csr.transaction_date', $transaction_date)->pluck('csri.qty', 'csri.item_code')->toArray();
+        $existing_record = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $branch)
+            ->where('transaction_date', $transaction_date)->pluck('qty', 'item_code')->toArray();
 
         return view('consignment.product_sold_form', compact('branch', 'transaction_date', 'items', 'item_images', 'existing_record', 'consigned_stocks'));
     }
@@ -585,7 +585,7 @@ class ConsignmentController extends Controller
     public function calendarData($branch, Request $request) {
         $start = $request->start;
         $end = $request->end;
-        $query = DB::table('tabConsignment Sales Report')->where('branch_warehouse', $branch)
+        $query = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $branch)
             ->whereBetween('transaction_date', [$start, $end])
             ->select('transaction_date', DB::raw('GROUP_CONCAT(DISTINCT status) as status'))
             ->groupBy('transaction_date')->get();

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -1490,6 +1490,9 @@ class ConsignmentController extends Controller
                 ->when($request->tab1_status && $request->tab1_status != 'All', function ($q) use ($request){
                     return $q->where('docstatus', $request->tab1_status);
                 })
+                ->when($request->tab1_purpose, function ($q) use ($request){
+                    return $q->where('transfer_as', $request->tab1_purpose);
+                })
                 ->where('naming_series', 'STEC-')
                 ->orderBy('docstatus', 'asc')
                 ->orderBy('creation', 'desc')

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -107,9 +107,11 @@ class ConsignmentController extends Controller
 
         $consigned_stocks = DB::table('tabBin')->whereIn('item_code', $item_codes)->where('warehouse', $branch)->pluck('consigned_qty', 'item_code')->toArray();
 
-        $item_total_sold = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $branch)
-            ->whereBetween('transaction_date', [$start, $end])->selectRaw('SUM(qty) as sold_qty, item_code')
-            ->groupBy('item_code')->pluck('sold_qty', 'item_code')->toArray();
+        $item_total_sold = DB::table('tabConsignment Sales Report as csr')
+            ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+            ->where('csr.branch_warehouse', $branch)
+            ->whereBetween('csr.transaction_date', [$start, $end])->selectRaw('SUM(csri.qty) as sold_qty, csri.item_code')
+            ->groupBy('csri.item_code')->pluck('sold_qty', 'csri.item_code')->toArray();
 
         $item_images = DB::table('tabItem Images')->whereIn('parent', $item_codes)->select('parent', 'image_path')->orderBy('idx', 'asc')->get();
         $item_images = collect($item_images)->groupBy('parent')->toArray();
@@ -392,7 +394,7 @@ class ConsignmentController extends Controller
                 ->where('branch_warehouse', $data['branch_warehouse'])->where('cutoff_period_from', $period_from)
                 ->where('cutoff_period_to', $period_to)->first();
 
-            $grand_total = 0;
+            $grand_total = $total_qty_sold = $total_items = 0;
             if (!$existing_record) {
                 $latest_id = DB::table('tabConsignment Sales Report')->max('name');
                 $latest_id_exploded = explode("-", $latest_id);
@@ -443,6 +445,8 @@ class ConsignmentController extends Controller
                         $no_of_items_updated++;
                         $amount = ((float)$price * (float)$row['qty']);
                         $grand_total += $amount;
+                        $total_qty_sold += $row['qty'];
+                        $total_items++;
                         $child_data[] = [
                             'name' => uniqid(),
                             'creation' => $currentDateTime->toDateTimeString(),
@@ -465,6 +469,8 @@ class ConsignmentController extends Controller
                 }
 
                 $parent_data['grand_total'] = $grand_total;
+                $parent_data['total_qty_sold'] = $total_qty_sold;
+                $parent_data['total_items'] = $total_items;
 
                 if (count($child_data) > 0) {
                     DB::table('tabConsignment Sales Report Item')->insert($child_data);
@@ -563,7 +569,9 @@ class ConsignmentController extends Controller
                 DB::table('tabConsignment Sales Report')->where('name', $existing_record->name)->update([
                     'modified' => $currentDateTime->toDateTimeString(),
                     'modified_by' => Auth::user()->wh_user,
-                    'grand_total' => $grand_total
+                    'grand_total' => $grand_total,
+                    'total_qty_sold' => $total_qty_sold,
+                    'total_items' => $total_items,
                 ]);
             }
    
@@ -833,10 +841,13 @@ class ConsignmentController extends Controller
         $beginning_inv_items = DB::table('tabConsignment Beginning Inventory Item')->whereIn('parent', $ids)->get();
         $beginning_inventory_items = collect($beginning_inv_items)->groupBy('parent');
 
-        $product_sold_arr = DB::table('tabConsignment Product Sold')->where('qty', '>', 0)->whereIn('branch_warehouse', $warehouses)->where('status', '!=', 'Cancelled')
-            ->select('transaction_date', 'branch_warehouse', 'item_code', 'description', 'price', DB::raw('sum(qty) as qty'), DB::raw('sum(amount) as amount'))
-            ->groupBy('transaction_date', 'branch_warehouse', 'item_code', 'description', 'price')
+        $product_sold_arr = DB::table('tabConsignment Sales Report as csr')
+            ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+            ->where('csri.qty', '>', 0)->whereIn('csr.branch_warehouse', $warehouses)->where('csr.status', '!=', 'Cancelled')
+            ->select('csr.transaction_date', 'csr.branch_warehouse', 'csri.item_code', 'csri.description', 'csri.price', DB::raw('sum(csri.qty) as qty'), 'csr.grand_total as amount')
+            ->groupBy('csr.transaction_date', 'csr.branch_warehouse', 'csri.item_code', 'csri.description', 'csri.price')
             ->get();
+
         $product_sold = collect($product_sold_arr)->groupBy('branch_warehouse');
         
         $sold_item_codes = collect($product_sold_arr)->map(function ($q){
@@ -2565,11 +2576,13 @@ class ConsignmentController extends Controller
 
         $result = [];
         foreach ($list as $row) {
-            $total_sales = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $row->branch_warehouse)
-                ->whereBetween('transaction_date', [$row->audit_date_from, $row->audit_date_to])->sum('amount');
+            $total_sales = DB::table('tabConsignment Sales Report')->where('branch_warehouse', $row->branch_warehouse)
+                ->whereBetween('transaction_date', [$row->audit_date_from, $row->audit_date_to])->sum('grand_total');
 
-            $total_qty_sold = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $row->branch_warehouse)
-                ->whereBetween('transaction_date', [$row->audit_date_from, $row->audit_date_to])->sum('qty');
+            $total_qty_sold = DB::table('tabConsignment Sales Report as csr')
+                ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+                ->where('csr.branch_warehouse', $row->branch_warehouse)
+                ->whereBetween('csr.transaction_date', [$row->audit_date_from, $row->audit_date_to])->sum('csri.qty');
 
             $result[] = [
                 'transaction_date' => $row->transaction_date,
@@ -2592,9 +2605,11 @@ class ConsignmentController extends Controller
             ->where('branch_warehouse', $store)->where('audit_date_from', $from)
             ->where('audit_date_to', $to)->get();
 
-        $product_sold_query = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $store)
-            ->whereBetween('transaction_date', [$from, $to])->selectRaw('SUM(qty) as sold_qty, SUM(amount) as total_value, item_code')
-            ->groupBy('item_code')->get();
+        $product_sold_query = DB::table('tabConsignment Sales Report as csr')
+            ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+            ->where('csr.branch_warehouse', $store)
+            ->whereBetween('csr.transaction_date', [$from, $to])->selectRaw('SUM(csri.qty) as sold_qty, SUM(csri.amount) as total_value, csri.item_code')
+            ->groupBy('csri.item_code')->get();
 
         $product_sold = collect($product_sold_query)->groupBy('item_code')->toArray();
         
@@ -2871,14 +2886,14 @@ class ConsignmentController extends Controller
         $store = $request->store;
         $year = $request->year;
 
-        $list = DB::table('tabConsignment Product Sold')
+        $list = DB::table('tabConsignment Sales Report')
             ->when($store, function ($q) use ($store){
                 return $q->where('branch_warehouse', $store);
             })
             ->when($year, function ($q) use ($year){
                 return $q->whereYear('cutoff_period_from', $year);
             })
-            ->selectRaw('branch_warehouse, cutoff_period_from, cutoff_period_to, SUM(qty) as total_sold, SUM(amount) as total_amount, COUNT(DISTINCT item_code) as total_item, GROUP_CONCAT(DISTINCT promodiser ORDER BY promodiser ASC SEPARATOR ",") as promodisers')
+            ->selectRaw('branch_warehouse, cutoff_period_from, cutoff_period_to, SUM(total_qty_sold) as total_sold, SUM(grand_total) as total_amount, GROUP_CONCAT(DISTINCT promodiser ORDER BY promodiser ASC SEPARATOR ",") as promodisers')
             ->orderBy('transaction_date', 'desc')->groupBy('branch_warehouse', 'cutoff_period_from', 'cutoff_period_to')
             ->paginate(20);
 
@@ -2886,14 +2901,15 @@ class ConsignmentController extends Controller
     }
 
     public function viewProductSoldItems($store, $from, $to) {
-        $list = DB::table('tabConsignment Product Sold')
-            ->where('branch_warehouse', $store)
-            ->where('cutoff_period_from', $from)
-            ->where('cutoff_period_to', $to)
-            ->selectRaw('item_code, description, SUM(qty) as qty, SUM(amount) as amount')
-            ->orderBy('description', 'asc')->groupBy('item_code', 'description')->get();
+        $list = DB::table('tabConsignment Sales Report as csr')
+            ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+            ->where('csr.branch_warehouse', $store)
+            ->where('csr.cutoff_period_from', $from)
+            ->where('csr.cutoff_period_to', $to)
+            ->selectRaw('csri.item_code, csri.description, SUM(csri.qty) as qty, SUM(csri.amount) as amount')
+            ->orderBy('csri.description', 'asc')->groupBy('csri.item_code', 'csri.description')->get();
 
-        $promodisers = DB::table('tabConsignment Product Sold')
+        $promodisers = DB::table('tabConsignment Sales Report')
             ->where('branch_warehouse', $store)->where('cutoff_period_from', $from)
             ->where('cutoff_period_to', $to)->distinct()->pluck('promodiser')->toArray();
             
@@ -3040,12 +3056,13 @@ class ConsignmentController extends Controller
             $cutoff_end = $cutoff[1];
         }
 
-        $query = DB::table('tabConsignment Product Sold')
-            ->where('branch_warehouse', $store)
-            ->whereBetween('transaction_date', [$cutoff_start, $cutoff_end])
-            ->where('status', '!=', 'Cancelled')
-            ->select('item_code', 'description', 'qty', 'price', 'amount', 'transaction_date', 'promodiser', 'available_stock_on_transaction')
-            ->orderBy('description', 'asc')->orderBy('transaction_date', 'desc')->get();
+        $query = DB::table('tabConsignment Sales Report as csr')
+            ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
+            ->where('csr.branch_warehouse', $store)
+            ->whereBetween('csr.transaction_date', [$cutoff_start, $cutoff_end])
+            ->where('csr.status', '!=', 'Cancelled')
+            ->select('csri.item_code', 'csri.description', 'csri.qty', 'csri.price', 'csri.amount', 'csr.transaction_date', 'csr.promodiser', 'csri.available_stock_on_transaction')
+            ->orderBy('csri.description', 'asc')->orderBy('csr.transaction_date', 'desc')->get();
 
         $ending_inventory = collect($query)->groupBy('item_code')->toArray();
 

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -308,8 +308,8 @@ class ConsignmentController extends Controller
         $item_images = DB::table('tabItem Images')->whereIn('parent', $item_codes)->select('parent', 'image_path')->orderBy('idx', 'asc')->get();
         $item_images = collect($item_images)->groupBy('parent')->toArray();
 
-        $existing_record = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $branch)
-            ->where('transaction_date', $transaction_date)->pluck('qty', 'item_code')->toArray();
+        $existing_record = DB::table('tabConsignment Sales Report as csr')->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')->where('csr.branch_warehouse', $branch)
+            ->where('csr.transaction_date', $transaction_date)->pluck('csri.qty', 'csri.item_code')->toArray();
 
         return view('consignment.product_sold_form', compact('branch', 'transaction_date', 'items', 'item_images', 'existing_record', 'consigned_stocks'));
     }
@@ -585,7 +585,7 @@ class ConsignmentController extends Controller
     public function calendarData($branch, Request $request) {
         $start = $request->start;
         $end = $request->end;
-        $query = DB::table('tabConsignment Product Sold')->where('branch_warehouse', $branch)
+        $query = DB::table('tabConsignment Sales Report')->where('branch_warehouse', $branch)
             ->whereBetween('transaction_date', [$start, $end])
             ->select('transaction_date', DB::raw('GROUP_CONCAT(DISTINCT status) as status'))
             ->groupBy('transaction_date')->get();

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -365,6 +365,7 @@ class ConsignmentController extends Controller
             $period_to = $cutoff_date[1];
             
             $currentDateTime = Carbon::now();
+            $result = [];
             $no_of_items_updated = 0;
 
             $status = 'On Time';
@@ -388,185 +389,90 @@ class ConsignmentController extends Controller
             $consigned_stocks = DB::table('tabBin')->whereIn('item_code', array_keys($data['item']))
                 ->where('warehouse', $data['branch_warehouse'])->pluck('consigned_qty', 'item_code')->toArray();
 
-            $existing_record = DB::table('tabConsignment Sales Report')->where('transaction_date', $data['transaction_date'])
-                ->where('branch_warehouse', $data['branch_warehouse'])->where('cutoff_period_from', $period_from)
-                ->where('cutoff_period_to', $period_to)->first();
+            foreach ($data['item'] as $item_code => $row) {
+                $consigned_qty = array_key_exists($item_code, $consigned_stocks) ? $consigned_stocks[$item_code] : 0;
+                $existing = DB::table('tabConsignment Product Sold')
+                    ->where('item_code', $item_code)->where('branch_warehouse', $data['branch_warehouse'])
+                    ->where('transaction_date', $data['transaction_date'])->first();
+                if ($existing) {
+                    $consigned_qty = $consigned_qty + $existing->qty;
 
-            $grand_total = 0;
-            if (!$existing_record) {
-                $latest_id = DB::table('tabConsignment Sales Report')->max('name');
-                $latest_id_exploded = explode("-", $latest_id);
-                $new_id = (($latest_id) ? $latest_id_exploded[1] : 0) + 1;
-                $new_id = str_pad($new_id, 7, '0', STR_PAD_LEFT);
-                $new_id = 'CSR-'.$new_id;
-    
-                $parent_data = [
-                    'name' => $new_id,
-                    'creation' => $currentDateTime->toDateTimeString(),
-                    'modified' => $currentDateTime->toDateTimeString(),
-                    'modified_by' => Auth::user()->wh_user,
-                    'owner' => Auth::user()->wh_user,
-                    'docstatus' => 0,
-                    'parent' => null,
-                    'parentfield' => null,
-                    'parenttype' => null,
-                    'idx' => 0,
-                    'transaction_date' => $data['transaction_date'],
-                    'branch_warehouse' => $data['branch_warehouse'],
-                    'grand_total' => null,
-                    'promodiser' => Auth::user()->full_name,
-                    'status' => $status,
-                    'cutoff_period_from' => $period_from,
-                    'cutoff_period_to' => $period_to,
-                ];
-
-                $child_data = [];
-                foreach ($data['item'] as $item_code => $row) {
-                    if ($row['qty'] > 0) {
-                        $consigned_qty = array_key_exists($item_code, $consigned_stocks) ? $consigned_stocks[$item_code] : 0;
-                        $price = array_key_exists($item_code, $item_prices) ? $item_prices[$item_code][0]->price : 0;
-                        if ((float)$row['qty'] < 0) {
-                            return redirect()->back()
-                                ->with(['old_data' => $data])
-                                ->with('error', 'Qty for <b>' . $item_code . '</b> cannot be less than 0.');
-                        }
-    
-                        if ($consigned_qty < (float)$row['qty']) {
-                            return redirect()->back()
-                                ->with(['old_data' => $data])
-                                ->with('error', 'Insufficient stock for <b>' . $item_code . '</b>.<br>Available quantity is <b>' . number_format($consigned_qty) . '</b>.');
-                        }
-    
-                        DB::table('tabBin')->where('item_code', $item_code)->where('warehouse', $data['branch_warehouse'])
-                            ->update(['consigned_qty' => (float)$consigned_qty - (float)$row['qty']]);
-                        
-                        $no_of_items_updated++;
-                        $amount = ((float)$price * (float)$row['qty']);
-                        $grand_total += $amount;
-                        $child_data[] = [
-                            'name' => uniqid(),
-                            'creation' => $currentDateTime->toDateTimeString(),
-                            'modified' => $currentDateTime->toDateTimeString(),
-                            'modified_by' => Auth::user()->wh_user,
-                            'owner' => Auth::user()->wh_user,
-                            'docstatus' => 0,
-                            'parent' => $new_id,
-                            'parentfield' => 'items',
-                            'parenttype' => 'Consignment Sales Report',
-                            'idx' => $no_of_items_updated,
-                            'item_code' => $item_code,
-                            'description' => $row['description'],
-                            'qty' => $row['qty'],
-                            'price' => (float)$price,
-                            'amount' => $amount,
-                            'available_stock_on_transaction' => $consigned_qty
-                        ];
+                    if ($consigned_qty < (float)$row['qty']) {
+                        return redirect()->back()
+                            ->with(['old_data' => $data])
+                            ->with('error', 'Insufficient stock for <b>' . $item_code . '</b>.<br>Available quantity is <b>' . number_format($consigned_qty) . '</b>.');
                     }
-                }
 
-                $parent_data['grand_total'] = $grand_total;
+                    if ((float)$row['qty'] < 0) {
+                        return redirect()->back()
+                            ->with(['old_data' => $data])
+                            ->with('error', 'Qty for <b>' . $item_code . '</b> cannot be less than 0.');
+                    }
 
-                if (count($child_data) > 0) {
-                    DB::table('tabConsignment Sales Report Item')->insert($child_data);
-                    DB::table('tabConsignment Sales Report')->insert($parent_data);
-                }
-            }
+                    DB::table('tabBin')->where('item_code', $item_code)->where('warehouse', $data['branch_warehouse'])
+                        ->update(['consigned_qty' => (float)$consigned_qty - (float)$row['qty']]);
 
-            if ($existing_record) {
-                $child_data = [];
-                foreach ($data['item'] as $item_code => $row) {
-                    $consigned_qty = array_key_exists($item_code, $consigned_stocks) ? $consigned_stocks[$item_code] : 0;
+                    // for update
+                    $values = [
+                        'modified' => $currentDateTime->toDateTimeString(),
+                        'modified_by' => Auth::user()->wh_user,
+                        'qty' => $row['qty'],
+                    ];
+
+                    $no_of_items_updated++;
+
+                    DB::table('tabConsignment Product Sold')->where('name', $existing->name)->update($values);
+                } else {
+                    // for insert
                     $price = array_key_exists($item_code, $item_prices) ? $item_prices[$item_code][0]->price : 0;
 
-                    $amount = ((float)$price * (float)$row['qty']);
-
-                    $existing = DB::table('tabConsignment Sales Report Item')
-                        ->where('item_code', $item_code)->where('parent', $existing_record->name)->first();
-                        
-                    if ($existing) {
-                        $consigned_qty = $consigned_qty + $existing->qty;
-
-                        if ($consigned_qty < (float)$row['qty']) {
-                            return redirect()->back()
-                                ->with(['old_data' => $data])
-                                ->with('error', 'Insufficient stock for <b>' . $item_code . '</b>.<br>Available quantity is <b>' . number_format($consigned_qty) . '</b>.');
-                        }
-
-                        if ((float)$row['qty'] < 0) {
-                            return redirect()->back()
-                                ->with(['old_data' => $data])
-                                ->with('error', 'Qty for <b>' . $item_code . '</b> cannot be less than 0.');
-                        }
-
-                        DB::table('tabBin')->where('item_code', $item_code)->where('warehouse', $data['branch_warehouse'])
-                            ->update(['consigned_qty' => (float)$consigned_qty - (float)$row['qty']]);
-
-                        // for update
-                        $values = [
-                            'modified' => $currentDateTime->toDateTimeString(),
-                            'modified_by' => Auth::user()->wh_user,
-                            'qty' => $row['qty'],
-                            'amount' => $amount
-                        ];
-
-                        $no_of_items_updated++;
-                        $grand_total += $amount;
-
-                        DB::table('tabConsignment Sales Report Item')->where('name', $existing->name)->update($values);
-                    } else {
-                        // for insert
-                        if ($row['qty'] > 0) {
-                            if ((float)$row['qty'] < 0) {
-                                return redirect()->back()
-                                    ->with(['old_data' => $data])
-                                    ->with('error', 'Qty for <b>' . $item_code . '</b> cannot be less than 0.');
-                            }
-    
-                            if ($consigned_qty < (float)$row['qty']) {
-                                return redirect()->back()
-                                    ->with(['old_data' => $data])
-                                    ->with('error', 'Insufficient stock for <b>' . $item_code . '</b>.<br>Available quantity is <b>' . number_format($consigned_qty) . '</b>.');
-                            }
-    
-                            DB::table('tabBin')->where('item_code', $item_code)->where('warehouse', $data['branch_warehouse'])
-                                ->update(['consigned_qty' => (float)$consigned_qty - (float)$row['qty']]);
-                            
-                            $no_of_items_updated++;
-                            $grand_total += $amount;
-    
-                            $child_data[] = [
-                                'name' => uniqid(),
-                                'creation' => $currentDateTime->toDateTimeString(),
-                                'modified' => $currentDateTime->toDateTimeString(),
-                                'modified_by' => Auth::user()->wh_user,
-                                'owner' => Auth::user()->wh_user,
-                                'docstatus' => 0,
-                                'parent' => $existing_record->name,
-                                'parentfield' => 'items',
-                                'parenttype' => 'Consignment Sales Report',
-                                'idx' => $no_of_items_updated,
-                                'item_code' => $item_code,
-                                'description' => $row['description'],
-                                'qty' => $row['qty'],
-                                'price' => (float)$price,
-                                'amount' => $amount,
-                                'available_stock_on_transaction' => $consigned_qty
-                            ];
-                        }
+                    if ((float)$row['qty'] < 0) {
+                        return redirect()->back()
+                            ->with(['old_data' => $data])
+                            ->with('error', 'Qty for <b>' . $item_code . '</b> cannot be less than 0.');
                     }
-                }
 
-                if (count($child_data) > 0) {
-                    DB::table('tabConsignment Sales Report Item')->insert($child_data);
-                }
+                    if ($consigned_qty < (float)$row['qty']) {
+                        return redirect()->back()
+                            ->with(['old_data' => $data])
+                            ->with('error', 'Insufficient stock for <b>' . $item_code . '</b>.<br>Available quantity is <b>' . number_format($consigned_qty) . '</b>.');
+                    }
 
-                DB::table('tabConsignment Sales Report')->where('name', $existing_record->name)->update([
-                    'modified' => $currentDateTime->toDateTimeString(),
-                    'modified_by' => Auth::user()->wh_user,
-                    'grand_total' => $grand_total
-                ]);
+                    DB::table('tabBin')->where('item_code', $item_code)->where('warehouse', $data['branch_warehouse'])
+                        ->update(['consigned_qty' => (float)$consigned_qty - (float)$row['qty']]);
+                    
+                    $no_of_items_updated++;
+                    $result[] = [
+                        'name' => uniqid(),
+                        'creation' => $currentDateTime->toDateTimeString(),
+                        'modified' => $currentDateTime->toDateTimeString(),
+                        'modified_by' => Auth::user()->wh_user,
+                        'owner' => Auth::user()->wh_user,
+                        'docstatus' => 0,
+                        'parent' => null,
+                        'parentfield' => null,
+                        'parenttype' => null,
+                        'idx' => 0,
+                        'transaction_date' => $data['transaction_date'],
+                        'branch_warehouse' => $data['branch_warehouse'],
+                        'item_code' => $item_code,
+                        'description' => $row['description'],
+                        'qty' => $row['qty'],
+                        'promodiser' => Auth::user()->full_name,
+                        'price' => (float)$price,
+                        'status' => $status,
+                        'amount' => ((float)$price * (float)$row['qty']),
+                        'cutoff_period_from' => $period_from,
+                        'cutoff_period_to' => $period_to,
+                        'available_stock_on_transaction' => $consigned_qty
+                    ];
+                }
             }
-   
+
+            if (count($result) > 0) {
+                DB::table('tabConsignment Product Sold')->insert($result);
+            }
+
             DB::commit();
 
             return redirect()->back()->with([

--- a/resources/views/consignment/beginning_inv_items.blade.php
+++ b/resources/views/consignment/beginning_inv_items.blade.php
@@ -313,6 +313,10 @@
 
             $('#item-count').text(parseInt($('#item-count').text()) - 1);
 
+            items_array = jQuery.grep(items_array, function(value) {
+                return value != item_code;
+            });
+
             if(existing_record == 1){
                 enable_submit();
             }
@@ -424,7 +428,8 @@
                 dataType: 'json',
                 data: function (data) {
                     return {
-                        q: data.term // search term
+                        q: data.term, // search term
+                        excluded_items: items_array
                     };
                 },
                 processResults: function (response) {
@@ -505,6 +510,7 @@
             validate_submit();
         });
 
+        var items_array = new Array();
         function add_item(table){
             var item_code = $('#new-item-code').text();
             var description = $('#new-description').text();
@@ -560,10 +566,17 @@
 
 			$(table).prepend(row);
             $('#placeholder').addClass('d-none');
+
+            if(jQuery.inArray(item_code, items_array) === -1){
+                items_array.push(item_code);
+            }
             
             if(existing_record == 1){
                 enable_submit();
             }
+
+            $("#item-selection").empty().trigger('change');
+
             validate_submit();
 		}
 

--- a/resources/views/consignment/promodiser_damage_report_form.blade.php
+++ b/resources/views/consignment/promodiser_damage_report_form.blade.php
@@ -59,7 +59,7 @@
                                                                 <table class="table table-striped d-none" id="item-selection-table">
                                                                     <thead>
                                                                         <th class="font-responsive text-center p-1 align-middle" style="width: 42%">Item Code</th>
-                                                                        <th class="font-responsive text-center p-1 align-middle">Opening Stock</th>
+                                                                        <th class="font-responsive text-center p-1 align-middle">Damaged Qty</th>
                                                                         <th class="font-responsive text-center p-1 align-middle">Price</th>
                                                                     </thead>
                                                                     <tbody>
@@ -122,7 +122,7 @@
                                             <table class="table table-striped" id="selected-items-table" style="font-size: 9pt;">
                                                 <thead>
                                                     <th class="font-responsive text-center p-1 align-middle">Item Code</th>
-                                                    <th class="font-responsive text-center p-1 align-middle">Opening Stock</th>
+                                                    <th class="font-responsive text-center p-1 align-middle">Damaged Qty</th>
                                                     <th class="font-responsive text-center p-1 align-middle">Price</th>
                                                 </thead>
                                                 <tbody>
@@ -451,7 +451,7 @@
                                 '</div>' +
                             '</div>' +
                             '<div class="p-1 col-2 text-right">' +
-                                '<span id="selected-item-price" style="font-size: 10pt;">' + price + '</span>' +
+                                '<span id="selected-item-price" style="font-size: 10pt; white-space: nowrap;">' + price + '</span>' +
                             '</div>' +
                             '<div class="p-1 col font-responsive remove-item" style="width: 15px !important; color: red; cursor: pointer" data-id="' + item_code + '"><i class="fa fa-remove"></i></div>' +
                         '</div>' +

--- a/resources/views/consignment/promodiser_damage_report_form.blade.php
+++ b/resources/views/consignment/promodiser_damage_report_form.blade.php
@@ -178,13 +178,15 @@
 
                 $('#add-modal-btn').prop('disabled', false);
 
+                items_array = [];
+
                 validate_submit();
             });
 
+            var items_array = new Array();
             function get_items(branch){
 				$('#item-selection').select2({
                     templateResult: formatState,
-                    // templateSelection: formatState,
                     placeholder: 'Select an item',
                     allowClear: true,
                     ajax: {
@@ -193,7 +195,8 @@
                         dataType: 'json',
                         data: function (data) {
                             return {
-                                q: data.term // search term
+                                q: data.term, // search term
+                                excluded_items: items_array
                             };
                         },
                         processResults: function (response) {
@@ -396,17 +399,11 @@
 
 
             function remove_items(item_code){
-                $('#' + item_code).val('');
-                $('#' + item_code).attr('name', '');
-                $('#reason-' + item_code).val('');
-                $('#reason-' + item_code).attr('name', '');
-                $('#reason-' + item_code).prop('required', false);
-                $('#reason-' + item_code).removeClass('reason');
-                $('#row-' + item_code).addClass('d-none');
-                $('#' + item_code + '-stock').removeClass('validate');
-                $('#' + item_code + '-stock').attr('name', '');
-                $('#' + item_code + '-stock').val('');
-                $('#' + item_code + '-stock').prop('required', false);
+                $('#row-' + item_code).remove();
+
+                items_array = jQuery.grep(items_array, function(value) {
+                    return value != item_code;
+                });
 
                 $('#item-counter').val(parseInt($('#item-counter').val()) - 1);
             }
@@ -465,6 +462,10 @@
                 '</tr>';
 
                 $(table).prepend(row);
+
+                if(jQuery.inArray(item_code, items_array) === -1){
+                    items_array.push(item_code);
+                }
 
                 truncate_description();
                 $('#item-counter').val(parseInt($('#item-counter').val()) + 1);

--- a/resources/views/consignment/promodiser_delivery_report.blade.php
+++ b/resources/views/consignment/promodiser_delivery_report.blade.php
@@ -45,6 +45,7 @@
                                             <div class="modal fade" id="{{ $ste['name'] }}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered" role="document">
                                                     <div class="modal-content">
+                                                        <form action="/promodiser/receive/{{ $ste['name'] }}" method="get">
                                                         <div class="modal-header bg-navy">
                                                             <h6 class="modal-title">Delivered Item(s)</h6>
                                                             <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
@@ -52,7 +53,6 @@
                                                             </button>
                                                         </div>
                                                         <div class="modal-body">
-                                                            <form></form>
                                                             <h5 class="text-center font-responsive font-weight-bold m-0">{{ $ste['to_consignment'] }}</h5>
                                                             <small class="d-block text-center mb-2">Delivery Date: {{ Carbon\Carbon::parse($ste['delivery_date'])->format('F d, Y') }}</small>
                                                             <div class="callout callout-info text-center">
@@ -62,7 +62,7 @@
                                                                 <thead>
                                                                     <th class="text-center p-1 align-middle" style="width: 40%">Item Code</th>
                                                                     <th class="text-center p-1 align-middle" style="width: 30%">Delivered Qty</th>
-                                                                    <th class="text-center p-1 align-middle" style="width: 30%">Amount</th>
+                                                                    <th class="text-center p-1 align-middle" style="width: 30%">Rate</th>
                                                                 </thead>
                                                                 <tbody>
                                                                     @foreach ($ste['items'] as $item)
@@ -129,27 +129,33 @@
                                                                             </div>
                                                                         </td>
                                                                         <td class="text-center p-1 align-middle">
-                                                                            <span class="d-block font-weight-bold">{{ $item['delivered_qty'] * 1 }}</span>
+                                                                            <span class="d-block font-weight-bold">{{ number_format($item['delivered_qty'] * 1) }}</span>
+                                                                            <span class="d-none font-weight-bold" id="{{ $item['item_code'] }}-qty">{{ $item['delivered_qty'] * 1 }}</span>
                                                                             <small>{{ $item['stock_uom'] }}</small>
                                                                         </td>
                                                                         <td class="text-center p-1 align-middle">
-                                                                        <span class="d-block font-weight-bold">₱ {{ number_format($item['price'] * 1, 2) }}</span>
+                                                                            <input type="text" name="item_codes[]" class="d-none" value="{{ $item['item_code'] }}"/>
+                                                                            <input type="number" value='{{ $item['price'] > 0 ? number_format($item['price'] * 1) : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
                                                                         </td>
                                                                     </tr>
                                                                     <tr>
                                                                         <td colspan="3" class="text-justify pt-0 pb-1 pl-1 pr-1" style="border-top: 0 !important;">
-                                                                            <span class="item-description">{!! strip_tags($item['description']) !!}</span>
+                                                                            <span class="item-description">{!! strip_tags($item['description']) !!}</span> <br>
+                                                                            Amount: ₱ <span id="{{ $item['item_code'] }}-amount" min='1' class='font-weight-bold amount'>{{ number_format($item['delivered_qty'] * $item['price'], 2) }}</span>
                                                                         </td>
                                                                     </tr>
                                                                     @endforeach
                                                                 </tbody>
                                                             </table>
                                                         </div>
-                                                        @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
                                                         <div class="modal-footer">
-                                                            <a href="/promodiser/receive/{{ $ste['name'] }}" class="btn btn-primary w-100">Receive</a>
+                                                            @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
+                                                                <button type="submit" class="btn btn-primary w-100">Receive</button>
+                                                            @else
+                                                                <button type="submit" class="btn btn-info w-100">Update Prices</button>
+                                                            @endif
                                                         </div>
-                                                        @endif
+                                                        </form>
                                                     </div>
                                                 </div>
                                             </div>
@@ -185,6 +191,17 @@
         .morectnt span {
             display: none;
         }
+        /* Chrome, Safari, Edge, Opera */
+        input::-webkit-outer-spin-button,
+        input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+        }
+
+        /* Firefox */
+        input[type=number] {
+        -moz-appearance: textfield;
+        }
     </style>
 @endsection
 
@@ -192,6 +209,21 @@
     <script>
         $(document).ready(function(){
             var showTotalChar = 150, showChar = "Show more", hideChar = "Show less";
+
+            $('.price').keyup(function(){
+                var item_code = $(this).data('item-code');
+                if($.isNumeric($(this).val()) && $(this).val() > 0){
+                    var qty = parseInt($('#'+item_code+'-qty').text());
+                    var total_amount = $(this).val() * qty;
+
+                    const amount = total_amount.toLocaleString('en-US', {maximumFractionDigits: 2});
+                    $('#'+item_code+'-amount').text(amount);
+                }else{
+                    $('#'+item_code+'-amount').text('0');
+                    $(this).val('');
+                }
+            });
+
             $('.item-description').each(function() {
                 var content = $(this).text();
                 if (content.length > showTotalChar) {

--- a/resources/views/consignment/stock_transfer_form.blade.php
+++ b/resources/views/consignment/stock_transfer_form.blade.php
@@ -255,6 +255,8 @@
 
                 get_received_items(src);
                 reset_placeholders();
+
+                items_array = [];
             });
 
             $('#src-warehouse').change(function(){
@@ -272,8 +274,11 @@
                 });
                 
                 $('#open-item-modal').prop('disabled', false);
+
                 reset_placeholders();
                 validate_submit();
+
+                items_array = [];
             });
 
             $('#target-warehouse').select2({
@@ -308,6 +313,8 @@
                         var item_code = $(this).val();
                         remove_items(item_code);
                     });
+                    items_array = [];
+
                     validate_submit();
                     reset_placeholders();
 
@@ -328,7 +335,8 @@
                         dataType: 'json',
                         data: function (data) {
                             return {
-                                q: data.term // search term
+                                q: data.term, // search term
+                                excluded_items: items_array
                             };
                         },
                         processResults: function (response) {
@@ -392,6 +400,11 @@
             function remove_items(item_code){
                 $('.row-' + item_code).remove();
                 var val = parseInt($('#counter').text()) - 1;
+
+                items_array = jQuery.grep(items_array, function(value) {
+                    return value != item_code;
+                });
+
                 val = val > 0 ? val : 0;
                 $('#counter').text(val);
             }
@@ -476,6 +489,7 @@
                 });
             });
 
+            var items_array = new Array();
             $('#add-item').click(function (){
                 var img = $('#img-text').text();
                 var alt = $('#alt-text').text();
@@ -529,6 +543,10 @@
                         '<div class="item-description">' + description + '</div>' +
                     '</td>' +
                 '</tr>';
+
+                if(jQuery.inArray(item_code, items_array) === -1){
+                    items_array.push(item_code);
+                }
 
                 $('#counter').text(parseInt($('#counter').text()) + 1);
                 $("#received-items").empty().trigger('change');

--- a/resources/views/consignment/supervisor/view_product_sold_list.blade.php
+++ b/resources/views/consignment/supervisor/view_product_sold_list.blade.php
@@ -4,9 +4,9 @@
 ])
 
 @section('content')
-<div class="content" style='min-height: 90vh'>
+<div class="content">
 	<div class="content-header p-0">
-        <div class="col-12 mx-auto">
+        <div class="container">
             <div class="row pt-1">
                 <div class="col-md-12 p-0 m-0">
                     <div class="row">
@@ -20,46 +20,27 @@
                         </div>
                     </div>
                     <div class="card card-secondary card-outline">
-                        <!-- Nav tabs -->
-					<ul class="nav nav-tabs" role="tablist">
-						<li class="nav-item">
-							<a class="nav-link active" data-toggle="tab" href="#list">List</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" data-toggle="tab" href="#report">Report</a>
-						</li>
-					</ul>
-				  
-					<!-- Tab panes -->
-					<div class="tab-content"> 
-						<div id="list" class="container-fluid tab-pane active" style="padding: 8px 0 0 0;">
-                            <div class="card-body p-2 col-12 col-xl-8 mx-auto">
-                                <form id="product-sold-form" method="GET">
-                                    <div class="d-flex flex-row align-items-center mt-2">
-                                        <div class="p-1 col-6">
-                                            <select class="form-control product-sold-filter" name="store" id="consignment-store-select">
-                                                <option value="">Select Store</option>
-                                            </select>
-                                        </div>
-                                        <div class="p-1 col-4 col-xl-2">
-                                            <select class="form-control product-sold-filter" name="year">
-                                                @foreach ($select_year as $year)
-                                                    <option value="{{ $year }}" {{ date('Y') == $year ? 'selected' : '' }}>{{ $year }}</option>
-                                                @endforeach
-                                            </select>
-                                        </div>
-                                        <div class="p-1 col-2">
-                                            <a href="/view_sales_report" class="btn btn-secondary"><i class="fas fa-undo"></i></a>
-                                        </div>
+                        <div class="card-body p-2 col-12">
+                            <form id="product-sold-form" method="GET">
+                                <div class="d-flex flex-row align-items-center mt-2">
+                                    <div class="p-1 col-6">
+                                        <select class="form-control product-sold-filter" name="store" id="consignment-store-select">
+                                            <option value="">Select Store</option>
+                                        </select>
                                     </div>
-                                </form>
-                                <div id="list-el" class="p-2"></div>
-                            </div>
-                        </div>
-						<div id="report" class="container-fluid tab-pane" style="padding: 8px 0 0 0;">
-                            <div class="row">
-                                <div id="report-container" class="container-fluid p-3"></div>
-                            </div>
+                                    <div class="p-1 col-4 col-xl-2">
+                                        <select class="form-control product-sold-filter" name="year">
+                                            @foreach ($select_year as $year)
+                                                <option value="{{ $year }}" {{ date('Y') == $year ? 'selected' : '' }}>{{ $year }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="p-1 col-2">
+                                        <a href="/view_sales_report" class="btn btn-secondary"><i class="fas fa-undo"></i></a>
+                                    </div>
+                                </div>
+                            </form>
+                            <div id="list-el" class="p-2"></div>
                         </div>
                     </div>
                 </div>
@@ -85,21 +66,6 @@
                 data: $('#product-sold-form').serialize(),
                 success: function (data) {
                     $('#list-el').html(data);
-                }
-            });
-        }
-
-        $('#test').click(function(){
-            loadSalesReport();
-        });
-
-        loadSalesReport();
-        function loadSalesReport() {
-            $.ajax({
-                type: "GET",
-                url: "/sales_report",
-                success: function (data) {
-                    $('#report-container').html(data);
                 }
             });
         }

--- a/resources/views/consignment/view_damaged_items_list.blade.php
+++ b/resources/views/consignment/view_damaged_items_list.blade.php
@@ -43,10 +43,21 @@
                                                     <div class="col-12 col-xl-2 col-lg-2">
                                                         <input type="text" name="tab1_q" class="form-control" placeholder='Search' style='font-size: 10pt;'/>
                                                     </div>
-                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-3 col-lg-3">
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-2 col-lg-2">
+                                                        <select name="tab1_purpose" id='status' class="form-control" style="font-size: 10pt;">
+                                                            @php
+                                                                $purposes = ['Store Transfer', 'Consignment', 'For Return', 'Sales Return'];
+                                                            @endphp 
+                                                            <option value="" selected>Select Purpose</option>
+                                                            @foreach ($purposes as $purpose)
+                                                            <option value="{{ $purpose }}">{{ $purpose }}</option>
+                                                            @endforeach
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-2 col-lg-2">
                                                         <select name="source_warehouse" id="source-warehouse" class="form-control" style="font-size: 10pt;"></select>
                                                     </div>
-                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-3 col-lg-3">
+                                                    <div class="col-12 mt-2 mt-lg-0 col-xl-2 col-lg-2">
                                                         <select name="target_warehouse" id="target-warehouse" class="form-control" style="font-size: 10pt;"></select>
                                                     </div>
                                                     <div class="col-12 mt-2 mt-lg-0 col-xl-2 col-lg-2">


### PR DESCRIPTION
# Release notes - AthenaERP Inventory - Version 5.3

### Bug

[AI-346](https://fumacoinc.atlassian.net/browse/AI-346) In Delivery List, Require input of price if item price is 0/null

[AI-341](https://fumacoinc.atlassian.net/browse/AI-341) In Stock Transfer, Transferred qty is added to the target warehouse after submitting the form

[AI-336](https://fumacoinc.atlassian.net/browse/AI-336) In Damaged Items Entry, Text shown is 'Opening Stock' instead of 'Damaged Qty' or 'Qty' in add items modal

[AI-335](https://fumacoinc.atlassian.net/browse/AI-335) In Stock Transfers, able to add the same item code multiple times

### Story

[AI-323](https://fumacoinc.atlassian.net/browse/AI-323) Fallback message/display once database is disconnected to replace laravel error message

### Task

[AI-340](https://fumacoinc.atlassian.net/browse/AI-340) In stock transfer list, add filter for "Purpose" for consignment supervisor

[AI-339](https://fumacoinc.atlassian.net/browse/AI-339) In sales report page, remove tab for report for consignment supervisor