### PR TITLE
Version 5.3.1

### DIFF
--- a/resources/views/consignment/inventory_audit_form.blade.php
+++ b/resources/views/consignment/inventory_audit_form.blade.php
@@ -56,7 +56,6 @@
                                             $img = array_key_exists($row->item_code, $item_images) ? "/img/" . $item_images[$row->item_code][0]->image_path : "/icon/no_img.png";
                                             $img_webp = array_key_exists($row->item_code, $item_images) ? "/img/" . explode('.',$item_images[$row->item_code][0]->image_path)[0].'.webp' : "/icon/no_img.webp";
                                             $sold_qty = array_key_exists($row->item_code, $item_total_sold) ? ($item_total_sold[$row->item_code] * 1) : 0;
-                                            $consigned_qty = array_key_exists($row->item_code, $consigned_stocks) ? ($consigned_stocks[$row->item_code] * 1) : 0;
 
                                             $img_count = array_key_exists($row->item_code, $item_images) ? count($item_images[$row->item_code]) : 0;
 
@@ -81,6 +80,7 @@
                                                     </div>
                                                     <div class="p-1 m-0">
                                                         <span class="font-weight-bold">{{ $row->item_code }}</span>
+                                                        <div class="d-none">{!! strip_tags($row->description) !!}</div>
                                                     </div>
                                                 </div>
                                                 <div class="modal fade" id="mobile-{{ $row->item_code }}-images-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -140,8 +140,8 @@
                                                 </div>
                                             </td>
                                             <td class="text-center p-1 align-middle font-weight-bold" style="border-bottom: 0 !important;">
-                                                <span class="d-block item-consigned-qty">{{ $consigned_qty }}</span>
-                                                <span class="d-none orig-item-consigned-qty">{{ $consigned_qty }}</span>
+                                                <span class="d-block item-consigned-qty">{{ number_format($row->consigned_qty) }}</span>
+                                                <span class="d-none orig-item-consigned-qty">{{ $row->consigned_qty }}</span>
                                             </td>
                                             <td class="text-center p-1 align-middle font-weight-bold" style="border-bottom: 0 !important;">
                                                 <span class="d-block item-sold-qty">{{ $sold_qty }}</span>
@@ -149,7 +149,10 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td colspan="4" style="border-top: 0 !important;"><div class="item-description">{!! strip_tags($row->description) !!}</div></td>
+                                            <td colspan="4" style="border-top: 0 !important;">
+                                                <span class="d-none">{{ $row->item_code }}</span>
+                                                <div class="item-description">{!! strip_tags($row->description) !!}</div>
+                                            </td>
                                         </tr>
                                         @empty
                                         <tr>

--- a/resources/views/consignment/product_sold_form.blade.php
+++ b/resources/views/consignment/product_sold_form.blade.php
@@ -52,7 +52,6 @@
                                             $img = array_key_exists($row->item_code, $item_images) ? "/img/" . $item_images[$row->item_code][0]->image_path : "/icon/no_img.png";
                                             $img_webp = array_key_exists($row->item_code, $item_images) ? "/img/" . explode('.',$item_images[$row->item_code][0]->image_path)[0].'.webp' : "/icon/no_img.webp";
                                             $qty = array_key_exists($row->item_code, $existing_record) ? ($existing_record[$row->item_code] * 1) : 0;
-                                            $consigned_qty = array_key_exists($row->item_code, $consigned_stocks) ? ($consigned_stocks[$row->item_code] * 1) : 0;
 
                                             $img_count = array_key_exists($row->item_code, $item_images) ? count($item_images[$row->item_code]) : 0;
 
@@ -83,14 +82,14 @@
                                                                 <button class="btn btn-outline-danger btn-xs qtyminus" style="padding: 0 5px 0 5px;" type="button">-</button>
                                                             </div>
                                                             <div class="custom-a p-0">
-                                                                <input type="number" class="form-control form-control-sm qty" value="{{ $qty }}" name="item[{{ $row->item_code }}][qty]" style="text-align: center; width: 80px;" data-max="{{ $consigned_qty }}">
+                                                                <input type="number" class="form-control form-control-sm qty" value="{{ $qty }}" name="item[{{ $row->item_code }}][qty]" style="text-align: center; width: 80px;" data-max="{{ $row->consigned_qty }}">
                                                             </div>
                                                             <div class="input-group-append p-0">
                                                                 <button class="btn btn-outline-success btn-xs qtyplus" style="padding: 0 5px 0 5px;" type="button">+</button>
                                                             </div>
                                                         </div>
                                                         <div class="text-center">
-                                                            <small>Available: {{ $consigned_qty }}</small>
+                                                            <small>Available: {{ number_format($row->consigned_qty) }}</small>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/resources/views/consignment/promodiser_delivery_report.blade.php
+++ b/resources/views/consignment/promodiser_delivery_report.blade.php
@@ -39,7 +39,7 @@
                                         <td class="text-left p-1 align-middle">
                                             <a href="#" data-toggle="modal" data-target="#{{ $ste['name'] }}-Modal">{{ $ste['to_consignment'] }}</a>
                                             <small class="d-block"><b>{{ $ste['name'] }}</b> | <b>Delivery Date:</b> {{ $delivery_date }}</small>
-                                            @if ($ste['status'] == 'Delivered')
+                                            @if ($ste['delivery_status'] == 1)
                                                 <small class="d-block"><b>Date Received:</b> {{ Carbon\Carbon::parse($ste['date_received'])->format('M d, Y - h:i a') }}</small>
                                             @endif
                                             <span class="badge badge-{{ $ste['status'] == 'Pending' ? 'warning' : 'success' }}">{{ $ste['status'] }}</span>
@@ -60,6 +60,9 @@
                                                         <div class="modal-body">
                                                             <h5 class="text-center font-responsive font-weight-bold m-0">{{ $ste['to_consignment'] }}</h5>
                                                             <small class="d-block text-center mb-2">{{ $ste['name'] }} | Delivery Date: {{ $delivery_date }}</small>
+                                                            @if ($ste['delivery_status'] == 1)
+                                                                <small class="d-block"><b>Date Received:</b> {{ Carbon\Carbon::parse($ste['date_received'])->format('M d, Y - h:i a') }}</small>
+                                                            @endif
                                                             <div class="callout callout-info text-center">
                                                                 <small><i class="fas fa-info-circle"></i> Once items are received, stocks will be automatically added to your current inventory.</small>
                                                             </div>
@@ -140,7 +143,7 @@
                                                                         </td>
                                                                         <td class="text-center p-1 align-middle">
                                                                             <input type="text" name="item_codes[]" class="d-none" value="{{ $item['item_code'] }}"/>
-                                                                            <input type="text" value='{{ number_format($item['price']) }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
+                                                                            <input type="text" value='{{ $item['price'] > 0 ? number_format($item['price']) : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
                                                                         </td>
                                                                     </tr>
                                                                     <tr>


### PR DESCRIPTION
# Release notes - AthenaERP Inventory - Version Version 5.3.1

### Bug

[AI-360](https://fumacoinc.atlassian.net/browse/AI-360) In Search Results and Item Profile, Different stock qty is shown in search results and item profile page

[AI-359](https://fumacoinc.atlassian.net/browse/AI-359) In Stock Transfers, Received item is not shown in Products Sold entry and Inventory Audit entry if item does not have beginning inventory entry

[AI-357](https://fumacoinc.atlassian.net/browse/AI-357) In sales report, no value displayed in opening stock and opening value for consignment supervisor

[AI-356](https://fumacoinc.atlassian.net/browse/AI-356) In Stock Adjustments, Incorrect amount is shown in the list

[AI-347](https://fumacoinc.atlassian.net/browse/AI-347) No Display of Assigned Warehouse for Promodiser in Search Result

### Story

[AI-353](https://fumacoinc.atlassian.net/browse/AI-353) Display STE number in "To Receive" Delivery for promodisers

[AI-352](https://fumacoinc.atlassian.net/browse/AI-352) Display STE number in Delivery Report for promodisers for transaction verification

[AI-350](https://fumacoinc.atlassian.net/browse/AI-350) Display Time in all Transaction Date for promodiser

[AI-348](https://fumacoinc.atlassian.net/browse/AI-348) Display Date/Time Received in Delivery Report for Promodiser