### PR TITLE
Version 5.3.3

### DIFF
--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -1985,9 +1985,9 @@ class ConsignmentController extends Controller
                 return redirect()->back()->with('error', 'No Beginning Inventory Record found for this item.');
             }
 
-            $consigned_qty = DB::table('tabBin')->where('warehouse', 'Quarantine Warehouse P2 - FI')->where('item_code', $damaged_item->item_code)->pluck('consigned_qty')->first();
+            $consigned_qty = DB::table('tabBin')->where('warehouse', 'Quarantine Warehouse - FI')->where('item_code', $damaged_item->item_code)->pluck('consigned_qty')->first();
             if($consigned_qty){
-                DB::table('tabBin')->where('warehouse', 'Quarantine Warehouse P2 - FI')->where('item_code', $damaged_item->item_code)->update([
+                DB::table('tabBin')->where('warehouse', 'Quarantine Warehouse - FI')->where('item_code', $damaged_item->item_code)->update([
                     'modified' => Carbon::now()->toDateTimeString(),
                     'modified_by' => Auth::user()->full_name,
                     'consigned_qty' => $consigned_qty + $damaged_item->qty
@@ -2007,7 +2007,7 @@ class ConsignmentController extends Controller
                     'owner' => Auth::user()->full_name,
                     'docstatus' => 0,
                     'idx' => 0,
-                    'warehouse' => 'Quarantine Warehouse P2 - FI',
+                    'warehouse' => 'Quarantine Warehouse - FI',
                     'item_code' => $damaged_item->item_code,
                     'stock_uom' => $damaged_item->stock_uom,
                     'valuation_rate' => $price,
@@ -2121,7 +2121,7 @@ class ConsignmentController extends Controller
             $transfer_qty = $request->item;
 
             $source_warehouse = $request->transfer_as == 'Sales Return' ? null : $request->source_warehouse;
-            $target_warehouse = $request->transfer_as == 'For Return' ? 'Quarantine Warehouse P2 - FI' : $request->target_warehouse;
+            $target_warehouse = $request->transfer_as == 'For Return' ? 'Quarantine Warehouse - FI' : $request->target_warehouse;
 
             $reference_warehouse = $request->transfer_as == 'Sales Return' ? $request->target_warehouse : $request->source_warehouse; // used to get data from bin
             if(!$item_codes || !$transfer_qty){

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -2080,7 +2080,7 @@ class ConsignmentController extends Controller
             ]);
 
             DB::commit();
-            
+
             return redirect()->back()->with('success', 'Item Returned.');
         } catch (Exception $e) {
             DB::rollback();
@@ -2090,7 +2090,6 @@ class ConsignmentController extends Controller
 
     public function getReceivedItems(Request $request, $branch){
         $search_str = explode(' ', $request->q);
-        $excluded_item_codes = $request->excluded_items ? $request->excluded_items : []; // exclude items already added in the items table
 
         $sold_item_codes = [];
         $sold_qty = [];
@@ -2153,9 +2152,6 @@ class ConsignmentController extends Controller
         $inventory_arr = DB::table('tabConsignment Beginning Inventory as inv')
             ->join('tabConsignment Beginning Inventory Item as item', 'item.parent', 'inv.name')
             ->where('inv.branch_warehouse', $branch)->where('inv.status', 'Approved')->where('item.status', 'Approved')->whereIn('item.item_code', $item_codes)
-            ->when($excluded_item_codes, function ($q) use ($excluded_item_codes){
-                return $q->whereNotIn('item.item_code', $excluded_item_codes);
-            })
             ->select('item.item_code', 'item.price', 'inv.transaction_date')->get();
 
         $inventory = collect($inventory_arr)->groupBy('item_code');

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -990,6 +990,11 @@ class ConsignmentController extends Controller
                 unset($update_values['price']);
             }
 
+            if($request->status == 'Approved'){
+                $update_values['approved_by'] = Auth::user()->full_name;
+                $update_values['date_approved'] = $now;
+            }
+
             DB::table('tabConsignment Beginning Inventory')->where('name', $id)->update($update_values);
 
             DB::commit();
@@ -1573,9 +1578,8 @@ class ConsignmentController extends Controller
                     'modified_by' => Auth::user()->full_name
                 ];
                 
-                DB::table('tabConsignment Beginning Inventory')->insert($values);
-
                 $row_values = [];
+                $grand_total = 0;
                 foreach($item_codes as $i => $item_code){
                     if(!$item_code || isset($opening_stock[$item_code]) && $opening_stock[$item_code] == 0){ // Prevents saving removed items and items with 0 opening stock
                         continue;
@@ -1584,8 +1588,11 @@ class ConsignmentController extends Controller
                     if(isset($opening_stock[$item_code]) && $opening_stock[$item_code] < 0 || isset($price[$item_code]) && $price[$item_code] < 0){
                         return redirect()->back()->with('error', 'Cannot enter value below 0');
                     }
+
+                    $item_price = isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0;
+                    $qty = isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0;
     
-                    $row_values = [
+                    $row_values[] = [
                         'name' => uniqid(),
                         'creation' => $now,
                         'owner' => Auth::user()->full_name,
@@ -1595,17 +1602,25 @@ class ConsignmentController extends Controller
                         'item_code' => $item_code,
                         'item_description' => isset($item[$item_code]) ? $item[$item_code][0]->description : null,
                         'stock_uom' => isset($item[$item_code]) ? $item[$item_code][0]->stock_uom : null,
-                        'opening_stock' => isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0,
+                        'opening_stock' => $qty,
                         'stocks_displayed' => 0,
                         'status' => 'For Approval',
-                        'price' => isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0,
+                        'price' => $item_price,
+                        'amount' => $item_price * $qty,
                         'modified' => $now,
                         'modified_by' => Auth::user()->full_name,
                         'parentfield' => 'items',
                         'parenttype' => 'Consignment Beginning Inventory' 
                     ];
+                    $grand_total += ($item_price * $qty);
 
                     $item_count = $item_count + 1;
+                }
+
+                $values['grand_total'] = $grand_total;
+
+                if (count($row_values) > 0) {
+                    DB::table('tabConsignment Beginning Inventory')->insert($values);    
                     DB::table('tabConsignment Beginning Inventory Item')->insert($row_values);
                 }
 
@@ -1617,11 +1632,7 @@ class ConsignmentController extends Controller
                 session()->flash('success', 'Beginning Inventory is Cancelled');
                 session()->flash('cancelled', 'Cancelled');
             }else{
-                DB::table('tabConsignment Beginning Inventory')->where('name', $request->inv_name)->update([
-                    'modified' => $now,
-                    'modified_by' => Auth::user()->wh_user
-                ]);
-                
+
                 $inventory_items = DB::table('tabConsignment Beginning Inventory Item')->where('parent', $request->inv_name)->pluck('item_code')->toArray();
                 $removed_items = array_diff($inventory_items, $item_codes->toArray());
 
@@ -1629,6 +1640,8 @@ class ConsignmentController extends Controller
                     DB::table('tabConsignment Beginning Inventory Item')->where('parent', $request->inv_name)->where('item_code', $remove)->delete();
                 }
 
+                $grand_total = 0;
+                $row_values = [];
                 foreach($item_codes as $i => $item_code){
                     if(!$item_code || isset($opening_stock[$item_code]) && $opening_stock[$item_code] == 0){ // Prevents saving removed items and items with 0 opening stock
                         continue;
@@ -1639,19 +1652,26 @@ class ConsignmentController extends Controller
                     }
 
                     if(in_array($item_code, $inventory_items)){
+                        $item_price = isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0;
+                        $qty = isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0;
+
                         $values = [
                             'modified' => $now,
                             'modified_by' => Auth::user()->wh_user,
                             'item_description' => isset($item[$item_code]) ? $item[$item_code][0]->description : null,
                             'stock_uom' => isset($item[$item_code]) ? $item[$item_code][0]->stock_uom : null,
-                            'opening_stock' => isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0,
-                            'price' => isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0,
+                            'opening_stock' => $qty,
+                            'price' => $item_price,
+                            'amount' => $item_price * $qty
                         ];
+
+                        $grand_total += ($item_price * $qty);
 
                         DB::table('tabConsignment Beginning Inventory Item')->where('parent', $request->inv_name)->where('item_code', $item_code)->update($values);
                     }else{
-                        $idx = count($inventory_items) + ($i + 1);
-                        $row_values = [
+                        $idx = count($inventory_items) + ($i + 1); $item_price = isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0;
+                        $qty = isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0;
+                        $row_values[] = [
                             'name' => uniqid(),
                             'creation' => $now,
                             'owner' => Auth::user()->full_name,
@@ -1661,20 +1681,34 @@ class ConsignmentController extends Controller
                             'item_code' => $item_code,
                             'item_description' => isset($item[$item_code]) ? $item[$item_code][0]->description : null,
                             'stock_uom' => isset($item[$item_code]) ? $item[$item_code][0]->stock_uom : null,
-                            'opening_stock' => isset($opening_stock[$item_code]) ? preg_replace("/[^0-9 .]/", "", $opening_stock[$item_code]) : 0,
+                            'opening_stock' => $qty,
                             'stocks_displayed' => 0,
                             'status' => 'For Approval',
-                            'price' => isset($price[$item_code]) ? preg_replace("/[^0-9 .]/", "", $price[$item_code]) : 0,
+                            'price' => $item_price,
+                            'amount' => $item_price * $qty,
                             'modified' => $now,
                             'modified_by' => Auth::user()->full_name,
                             'parentfield' => 'items',
                             'parenttype' => 'Consignment Beginning Inventory' 
                         ];
+
+                        $grand_total += ($item_price * $qty);
     
-                        DB::table('tabConsignment Beginning Inventory Item')->insert($row_values);
+                        
                     }
                     $item_count = $item_count + 1; 
                 }
+
+                if (count($row_values) > 0) {
+                    DB::table('tabConsignment Beginning Inventory Item')->insert($row_values);
+                }
+
+                DB::table('tabConsignment Beginning Inventory')->where('name', $request->inv_name)->update([
+                    'modified' => $now,
+                    'modified_by' => Auth::user()->wh_user,
+                    'grand_total' => $grand_total
+                ]);
+
                 session()->flash('success', 'Beginning Inventory is Updated');
             }
 

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -121,6 +121,7 @@ class MainController extends Controller
                 $duration = Carbon::parse($duration_from)->addDay()->format('M d, Y') . ' - ' . Carbon::parse($duration_to)->format('M d, Y');
 
                 $total_item_sold = DB::table('tabConsignment Product Sold')
+                    ->where('status', '!=', 'Cancelled')
                     ->whereIn('branch_warehouse', $assigned_consignment_store)->where('qty', '>', 0)
                     ->whereBetween('transaction_date', [Carbon::parse($duration_from)->addDay()->format('Y-m-d'), Carbon::parse($duration_to)->format('Y-m-d')])
                     ->count();
@@ -381,6 +382,7 @@ class MainController extends Controller
         $total_stock_adjustments = DB::table('tabConsignment Beginning Inventory')->count();
 
         $total_item_sold = DB::table('tabConsignment Product Sold')->where('qty', '>', 0)
+            ->where('status', '!=', 'Cancelled')
             ->whereBetween('transaction_date', [Carbon::parse($duration_from)->format('Y-m-d'), Carbon::parse($duration_to)->format('Y-m-d')])
             ->groupBy('branch_warehouse')->count();
 
@@ -5433,6 +5435,7 @@ class MainController extends Controller
     public function consignmentSalesReport($warehouse, Request $request) {
         $year = $request->year ? $request->year : Carbon::now()->format('Y');
         $query = DB::table('tabConsignment Product Sold')
+            ->where('status', '!=', 'Cancelled')
             ->whereYear('transaction_date', $year)->where('branch_warehouse', $warehouse)
             ->selectRaw('MONTH(transaction_date) as transaction_month, SUM(amount) as grand_total')
             ->groupBy('transaction_month')->pluck('grand_total', 'transaction_month')->toArray();

--- a/resources/views/consignment/beginning_inv_items_list.blade.php
+++ b/resources/views/consignment/beginning_inv_items_list.blade.php
@@ -33,12 +33,20 @@
                             }
                         @endphp
                         <span class="badge badge-{{ $badge }}">{{ $beginning_inventory->status }}</span>
-                            <div class="d-flex flex-row mt-2" style="font-size: 9pt;">
-                                <div class="p-0 col-7">
-                                    <span class="d-block">Date: <b>{{ Carbon\Carbon::parse($beginning_inventory->transaction_date)->format('F d, Y - h:i a') }}</b></span>
+                            <div class="d-flex flex-row mt-2 pl-2" style="font-size: 9pt;">
+                                <div class="p-0 col-7 text-left">
+                                    <span class="d-block">Date: <b>{{ Carbon\Carbon::parse($beginning_inventory->transaction_date)->format('F d, Y - h:i A') }}</b></span>
                                 </div>
                                 <div class="p-0 col-5">
                                     <span class="d-block">Total item(s): <b>{{ count($inventory) }}</b></span>
+                                </div>
+                            </div>
+                            <div class="d-flex flex-row pl-2" style="font-size: 9pt;">
+                                <div class="p-0 col-12 text-left">
+                                    @if ($beginning_inventory->status == 'Approved')
+                                    <span class="d-block">Approved by: <b>{{ $beginning_inventory->approved_by }}</b></span>
+                                    <span class="d-block">Date Approved: <b>{{ Carbon\Carbon::parse($beginning_inventory->date_approved)->format('M d, Y - h:i A') }}</b></span>
+                                @endif
                                 </div>
                             </div>
                             <div class="col-12">

--- a/resources/views/consignment/beginning_inv_list.blade.php
+++ b/resources/views/consignment/beginning_inv_list.blade.php
@@ -34,7 +34,7 @@
                             <table class="table table-striped">
                                 <thead class="text-uppercase">
                                     <th class="font-responsive text-center p-2">Date</th>
-                                    <th class="font-responsive text-center p-2" style="width: 65%;">Branch Warehouse</th>
+                                    <th class="font-responsive text-center p-2" style="width: 70%;">Branch Warehouse</th>
                                 </thead>
                                 @forelse ($beginning_inventory as $store)
                                     @php
@@ -47,11 +47,16 @@
                                     @endphp
                                     <tr>
                                         <td class="font-responsive text-center p-2 align-middle">
-                                            <small class="d-block">{{ Carbon\Carbon::parse($store->transaction_date)->format('M d, Y - h:i a') }}</small>
+                                            <small class="d-block">{{ Carbon\Carbon::parse($store->transaction_date)->format('M d, Y - h:i A') }}</small>
                                             <span class="badge badge-{{ $badge }}">{{ $store->status }}</span>
                                         </td>
                                         <td class="font-responsive p-2 align-middle">
                                             <a href="/beginning_inventory{{ ($store->status == 'For Approval' ? '/' : '_items/').$store->name }}">{{ $store->branch_warehouse }}</a>
+
+                                            @if ($store->status == 'Approved')
+                                                <small class="d-block">Approved by: {{ $store->approved_by }}</small>
+                                                <small class="d-block">Date: {{ Carbon\Carbon::parse($store->date_approved)->format('M d, Y - h:i A') }}</small>
+                                            @endif
                                         </td>
                                     </tr>
                                 @empty

--- a/resources/views/consignment/index_promodiser.blade.php
+++ b/resources/views/consignment/index_promodiser.blade.php
@@ -204,13 +204,6 @@
                                         </div>
                                     </div>
                                     </td>
-                                    {{-- <td class="text-center p-1 align-middle">
-                                      <span class="d-block font-weight-bold">{{ $item['delivered_qty'] * 1 }}</span>
-                                      <small>{{ $item['stock_uom'] }}</small>
-                                    </td>
-                                    <td class="text-center p-1 align-middle">
-                                      <span class="d-block font-weight-bold">₱ {{ number_format($item['price'] * 1, 2) }}</span>
-                                    </td> --}}
                                     <td class="text-center p-1 align-middle">
                                       <span class="d-block font-weight-bold">{{ number_format($item['delivered_qty'] * 1) }}</span>
                                       <span class="d-none font-weight-bold" id="{{ $item['item_code'] }}-qty">{{ $item['delivered_qty'] * 1 }}</span>
@@ -218,7 +211,7 @@
                                     </td>
                                     <td class="text-center p-1 align-middle">
                                         <input type="text" name="item_codes[]" class="d-none" value="{{ $item['item_code'] }}"/>
-                                        <input type="text" value='{{ $item['price'] > 0 ? number_format($item['price']) : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
+                                        <input type="text" value='{{ $item['price'] > 0 ? $item['price'] : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
                                     </td>
                                   </tr>
                                   <tr>
@@ -231,11 +224,6 @@
                                 </tbody>
                               </table>
                             </div>
-                            {{-- @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
-                            <div class="text-center m-3">
-                              <a href="/promodiser/receive/{{ $ste['name'] }}" class="btn btn-primary w-100">Receive</a>
-                            </div>
-                            @endif --}}
                             <div class="modal-footer">
                               @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
                                   <button type="submit" class="btn btn-primary w-100">Receive</button>

--- a/resources/views/consignment/promodiser_delivery_report.blade.php
+++ b/resources/views/consignment/promodiser_delivery_report.blade.php
@@ -143,7 +143,7 @@
                                                                         </td>
                                                                         <td class="text-center p-1 align-middle">
                                                                             <input type="text" name="item_codes[]" class="d-none" value="{{ $item['item_code'] }}"/>
-                                                                            <input type="text" value='{{ $item['price'] > 0 ? number_format($item['price']) : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
+                                                                            <input type="text" value='{{ $item['price'] > 0 ? $item['price'] : null }}' class='form-control text-center price' name='price[{{ $item['item_code'] }}]' data-item-code='{{ $item['item_code'] }}' placeholder='0' required>
                                                                         </td>
                                                                     </tr>
                                                                     <tr>

--- a/resources/views/consignment/stock_transfer_form.blade.php
+++ b/resources/views/consignment/stock_transfer_form.blade.php
@@ -89,7 +89,7 @@
                                                                     <table class="table" id='items-selection-table' style="font-size: 10pt;">
                                                                         <tr>
                                                                             <th class="text-center" style="width: 40%">Item</th>
-                                                                            <th class="text-center" style="width: 25%">Stocks</th>
+                                                                            <th class="text-center" style="width: 25%"><span class='qty-col'>Stocks</span></th>
                                                                             <th class="text-center transfer-text">Qty to Transfer</th>
                                                                         </tr>
                                                                         <tr>
@@ -112,7 +112,11 @@
                                                                                     </div>
                                                                                     <div class="col-3" style="display: flex; justify-content: center; align-items: center; height: 44px">
                                                                                         <div class="text-center">
-                                                                                            <b><span id="stocks-text"></span></b><br><small><span id="uom-text"></span></small>
+                                                                                            {{-- <b><span id="stocks-text"></span></b><br><small><span id="uom-text"></span></small> --}}
+                                                                                            <div>
+                                                                                                <b><span id="stocks-text"></span></b><br>
+                                                                                                <small><span id="uom-text"></span></small>
+                                                                                            </div>
                                                                                         </div>
                                                                                     </div>
                                                                                     <div class="col p-0">
@@ -152,7 +156,7 @@
                                             <thead>
                                                 <tr>
                                                     <th class="text-center" style="width: 40%">Item</th>
-                                                    <th class="text-center" style="width: 25%">Stocks</th>
+                                                    <th class="text-center" style="width: 25%"><span class='qty-col'>Stocks</span></th>
                                                     <th class="text-center transfer-text">Qty to Transfer</th>
                                                 </tr>
                                             </thead>
@@ -198,6 +202,7 @@
             $('#transfer-as').change(function (){
                 $('#target').slideDown();
                 var src = $('#src-warehouse').val();
+                $('.qty-col').text('Stocks');
                 if($(this).val() == 'Store Transfer'){
                     if($('#source').is(':hidden')){
                         $('#source').slideDown();
@@ -234,6 +239,7 @@
 
                     $('#src-warehouse').prop('required', false);
                     $('.transfer-text').text('Qty Returned');
+                    $('.qty-col').text('Qty Sold');
 
                     if($('#source').is(':visible')){
                         $('#source').slideUp();
@@ -252,6 +258,7 @@
 
                 $('#submit-btn').addClass('d-none');
                 $('#placeholder').removeClass('d-none');
+                $('#items-container').addClass('d-none');
 
                 get_received_items(src);
                 reset_placeholders();
@@ -326,7 +333,6 @@
             function get_received_items(branch){
                 $('#received-items').select2({
                     templateResult: formatState,
-                    // templateSelection: formatState,
                     placeholder: 'Select an Item',
                     allowClear: true,
                     ajax: {
@@ -336,7 +342,8 @@
                         data: function (data) {
                             return {
                                 q: data.term, // search term
-                                excluded_items: items_array
+                                excluded_items: items_array,
+                                purpose: $('#transfer-as').val()
                             };
                         },
                         processResults: function (response) {
@@ -516,7 +523,8 @@
                                 '<span class="font-weight-bold">' + item_code + '</span>' +
                             '</div>' +
                             '<div class="col-3 offset-1" style="display: flex; justify-content: center; align-items: center; height: 44px">' +
-                                '<span><b>' + stocks + '</b></span>&nbsp;<small>' + uom + '</small>' +
+                                '<div><span><b>' + stocks + '</b></span><br/>' +
+                                '<small>' + uom + '</small></div>' +
                             '</div>' +
                             '<div class="col p-0">' +
                                 '<div class="input-group p-1 ml-2">' +
@@ -617,8 +625,8 @@
             });
 
             cut_text();
+            var showTotalChar = 90, showChar = "Show more", hideChar = "Show less";
             function cut_text(){
-                var showTotalChar = 90, showChar = "Show more", hideChar = "Show less";
                 $('.item-description').each(function() {
                     var content = $(this).text();
                     if (content.length > showTotalChar) {
@@ -630,7 +638,7 @@
                 });
             }
 
-            $(".show-more").click(function(e) {
+            $('table#items-table').on('click', '.show-more', function(e){
                 e.preventDefault();
                 if ($(this).hasClass("sample")) {
                     $(this).removeClass("sample");

--- a/resources/views/consignment/stock_transfer_form.blade.php
+++ b/resources/views/consignment/stock_transfer_form.blade.php
@@ -507,7 +507,13 @@
                 var item_code = $('#item-code-text').text();
                 var description = $('#description-text').text();
 
-                var row = '<tr class="row-' + item_code + '">' +
+                var existing = $('#items-table').find('.' + item_code).eq(0).length;
+                if (existing) {
+                    showNotification("warning", 'Item <b>' + item_code + '</b> already exists in the list.', "fa fa-info");
+					return false;
+                }
+
+                var row = '<tr class="row-' + item_code + ' ' + item_code + '">' +
                     '<td colspan=3 class="text-center p-0">' +
                         '<div class="d-none">' + description + '</div>' + // reference for search
                         '<div class="row">' +
@@ -652,6 +658,21 @@
                 $(this).prev().toggle();
                 return false;
             });
+
+            function showNotification(color, message, icon){
+			$.notify({
+				icon: icon,
+				message: message
+			},{
+				type: color,
+				timer: 500,
+				z_index: 1060,
+				placement: {
+					from: 'top',
+					align: 'center'
+				}
+			});
+		}
         });
     </script>
 @endsection

--- a/resources/views/consignment/stock_transfers_list.blade.php
+++ b/resources/views/consignment/stock_transfers_list.blade.php
@@ -81,7 +81,7 @@
                                             <span class="font-weight-bold">{{ $ste['transfer_type'] }}</span>&nbsp;<span class="badge badge-{{ $badge }}">{{ $status }}</span>
                                         </div>
                                     </td>
-                                    <td class="d-none p-1 d-lg-table-cell">{{ $ste['to_warehouse'] == 'Quarantine Warehouse P2 - FI' ? 'Fumaco - Plant 2' : $ste['to_warehouse'] }}</td>
+                                    <td class="d-none p-1 d-lg-table-cell">{{ $ste['to_warehouse'] == 'Quarantine Warehouse - FI' ? 'Fumaco - Plant 2' : $ste['to_warehouse'] }}</td>
                                     @else {{-- Sales Returns --}}
                                     <td class="p-1">
                                         <div class="d-none d-lg-inline text-center">
@@ -236,7 +236,7 @@
                                     <td colspan="2" class="p-1 border-top-0 border-bottom">
                                         @if ($purpose == 'Material Transfer') {{-- Stock Transfers and Returns --}}
                                             <b>From: </b>{{ $ste['from_warehouse'] }} <br>
-                                            <b>To: </b>{{ $ste['to_warehouse'] == 'Quarantine Warehouse P2 - FI' ? 'Fumaco - Plant 2' : $ste['to_warehouse'] }} <br>
+                                            <b>To: </b>{{ $ste['to_warehouse'] == 'Quarantine Warehouse - FI' ? 'Fumaco - Plant 2' : $ste['to_warehouse'] }} <br>
                                         @else {{-- Sales Returns --}}
                                             <b>{{ $ste['to_warehouse'] }}</b> <br>
                                         @endif


### PR DESCRIPTION
# Release notes - AthenaERP Inventory - Version 5.3.3

### Bug

[AI-368](https://fumacoinc.atlassian.net/browse/AI-368) In Stock Transfers - For Return, wrong target warehouse

[AI-367](https://fumacoinc.atlassian.net/browse/AI-367) In Damaged Items, returning an item does not deduct the damaged qty from the consigned qty

[AI-366](https://fumacoinc.atlassian.net/browse/AI-366) In Stock Transfers Cancellation, cancelling a store transfer adds the transfer qty to the consigned qty

[AI-365](https://fumacoinc.atlassian.net/browse/AI-365) In Calendar View, Date still indicates a record of product sold for that day even after cancelling the beginning inventory

[AI-364](https://fumacoinc.atlassian.net/browse/AI-364) In Dashboard, Incoming items\(with beginning inventory\) does not have a price

[AI-363](https://fumacoinc.atlassian.net/browse/AI-363) In Sales Return, item sold is not in the list

[AI-335](https://fumacoinc.atlassian.net/browse/AI-335) In Stock Transfers, able to add the same item code multiple times