### PR TITLE
Version 5.5.2

### DIFF
--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -3593,7 +3593,7 @@ class ConsignmentController extends Controller
                 'img_count' => $img_count,
                 'total_value' => $total_value,
                 'opening_qty' => number_format($opening_qty),
-                'sold_qty' => $total_sold,
+                'sold_qty' => number_format($total_sold),
                 'audit_qty' => number_format($row->qty)
             ];
         }

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -3397,12 +3397,10 @@ class ConsignmentController extends Controller
                             $is_late++;
                         }
                     }
-        
-                    $check = Carbon::parse($start)->between($period_from, $period_to);
     
                     $duration = Carbon::parse($start)->addDay()->format('F d, Y') . ' - ' . Carbon::now()->format('F d, Y');
-                    if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
-                        if (!$check) {
+                    if (Carbon::parse($start)->addDay()->lt(Carbon::now())) {
+                        if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                             $pending_arr[] = [
                                 'store' => $store,
                                 'beginning_inventory_date' => $beginning_inventory_transaction_date,
@@ -3786,11 +3784,9 @@ class ConsignmentController extends Controller
                 }
             }
    
-            $check = Carbon::parse($start)->between($period_from, $period_to);
-    
             $duration = Carbon::parse($start)->addDay()->format('F d, Y') . ' - ' . Carbon::now()->format('F d, Y');
-            if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
-                if (!$check) {
+            if (Carbon::parse($start)->addDay()->lt(Carbon::now())) {
+                if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                     $pending[] = [
                         'store' => $store,
                         'beginning_inventory_date' => $beginning_inventory_transaction_date,
@@ -3800,19 +3796,17 @@ class ConsignmentController extends Controller
                         'promodisers' => $promodisers
                     ];
                 }
-             }
+            }
 
              if(!$beginning_inventory_transaction_date) {
-                 if (!$check) {
-                    $pending[] = [
-                        'store' => $store,
-                        'beginning_inventory_date' => $beginning_inventory_transaction_date,
-                        'last_inventory_audit_date' => $last_inventory_audit_date,
-                        'duration' => $duration,
-                        'is_late' => $is_late,
-                        'promodisers' => $promodisers
-                    ];
-                }
+                $pending[] = [
+                    'store' => $store,
+                    'beginning_inventory_date' => $beginning_inventory_transaction_date,
+                    'last_inventory_audit_date' => $last_inventory_audit_date,
+                    'duration' => $duration,
+                    'is_late' => $is_late,
+                    'promodisers' => $promodisers
+                ];
             }
         }
 

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -1511,7 +1511,7 @@ class ConsignmentController extends Controller
             })
             ->whereIn('ste.transfer_as', ['Consignment', 'Store Transfer'])
             ->where('ste.purpose', 'Material Transfer')
-            ->where('ste.docstatus', '<', 2)
+            ->where('ste.docstatus', 1)
             ->whereIn('ste.item_status', ['For Checking', 'Issued'])
             ->whereIn('sted.t_warehouse', $assigned_consignment_store)
             ->select('ste.name', 'ste.delivery_date', 'ste.item_status', 'ste.from_warehouse', 'sted.t_warehouse', 'sted.s_warehouse', 'ste.creation', 'ste.posting_time', 'sted.item_code', 'sted.description', 'sted.transfer_qty', 'sted.stock_uom', 'sted.basic_rate', 'sted.consignment_status', 'ste.transfer_as', 'ste.docstatus', 'sted.consignment_date_received')

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -3419,7 +3419,7 @@ class ConsignmentController extends Controller
                     }
     
                     $duration = Carbon::parse($start)->addDay()->format('F d, Y') . ' - ' . Carbon::now()->format('F d, Y');
-                    if (Carbon::parse($start)->addDay()->lt(Carbon::now())) {
+                    if (Carbon::parse($start)->addDay()->startOfDay()->lt(Carbon::now()->startOfDay())) {
                         if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                             $pending_arr[] = [
                                 'store' => $store,
@@ -3805,7 +3805,7 @@ class ConsignmentController extends Controller
             }
    
             $duration = Carbon::parse($start)->addDay()->format('F d, Y') . ' - ' . Carbon::now()->format('F d, Y');
-            if (Carbon::parse($start)->addDay()->lt(Carbon::now())) {
+            if (Carbon::parse($start)->addDay()->startOfDay()->lt(Carbon::now()->startOfDay())) {
                 if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                     $pending[] = [
                         'store' => $store,
@@ -3930,7 +3930,7 @@ class ConsignmentController extends Controller
     }
 
     public function viewPromodisersList() {
-        if (Auth::user()->user_group != 'Consignment Supervisor') {
+        if (!in_array(Auth::user()->user_group, ['Director', 'Consignment Supervisor'])) {
             return redirect('/');
         }
 

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -80,7 +80,7 @@ class ConsignmentController extends Controller
     public function viewInventoryAuditForm($branch, $transaction_date) {
         // get last inventory audit date
         $last_inventory_date = DB::table('tabConsignment Inventory Audit Report')
-            ->where('status', 'Approved')->where('branch_warehouse', $branch)->max('transaction_date');
+            ->where('branch_warehouse', $branch)->max('transaction_date');
 
         if (!$last_inventory_date) {
             // get beginning inventory date if last inventory date is not null

--- a/app/Http/Controllers/ConsignmentController.php
+++ b/app/Http/Controllers/ConsignmentController.php
@@ -2108,6 +2108,11 @@ class ConsignmentController extends Controller
     public function saveBeginningInventory(Request $request){
         DB::beginTransaction();
         try {
+
+            if(!$request->branch || $request->branch == 'null'){
+                return redirect()->back()->with('error', 'Please select a store');
+            }
+
             $opening_stock = $request->opening_stock;
             $opening_stock = preg_replace("/[^0-9 .]/", "", $opening_stock);
 

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -223,7 +223,7 @@ class MainController extends Controller
                     })
                     ->whereIn('ste.transfer_as', ['Consignment', 'Store Transfer'])
                     ->where('ste.purpose', 'Material Transfer')
-                    ->where('ste.docstatus', '<', 2)
+                    ->where('ste.docstatus', 1)
                     ->whereIn('ste.item_status', ['For Checking', 'Issued'])
                     ->whereIn('sted.t_warehouse', $assigned_consignment_store)
                     ->where(function($q) {

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -197,9 +197,8 @@ class MainController extends Controller
 
                         $start = $start->startOfDay();
             
-                        $check = Carbon::parse($start)->between($period_from, $period_to);
-                        if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
-                            if (!$check) {
+                        if (Carbon::parse($start)->addDay()->startOfDay()->lt(Carbon::parse($period_to)->startOfDay())) {
+                            if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                                 $total_pending_inventory_audit++;
                             }
                         }
@@ -452,9 +451,8 @@ class MainController extends Controller
 
             $start = $start->startOfDay();
 
-            $check = Carbon::parse($start)->between($period_from, $period_to);
-            if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
-                if (!$check) {
+            if (Carbon::parse($start)->addDay()->startOfDay()->lt(Carbon::parse($period_to)->startOfDay())) {
+                if ($last_audit_date->endOfDay()->lt($end) && $beginning_inventory_transaction_date) {
                     $total_pending_inventory_audit++;
                 }
             }

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -120,6 +120,8 @@ class MainController extends Controller
 
                 $duration = Carbon::parse($duration_from)->addDay()->format('M d, Y') . ' - ' . Carbon::parse($duration_to)->format('M d, Y');
 
+                $due = 'Due: '. Carbon::parse($duration_to)->format('M d, Y');
+
                 $total_item_sold = DB::table('tabConsignment Sales Report as csr')
                     ->join('tabConsignment Sales Report Item as csri', 'csr.name', 'csri.parent')
                     ->where('csri.qty', '>', 0)->where('csr.status', '!=', 'Cancelled')
@@ -316,7 +318,7 @@ class MainController extends Controller
                     }
                 }
 
-                return view('consignment.index_promodiser', compact('assigned_consignment_store', 'duration', 'inventory_summary', 'total_item_sold', 'total_pending_inventory_audit', 'total_stock_transfer', 'total_stock_adjustments', 'ste_arr', 'branches_with_pending_beginning_inventory'));
+                return view('consignment.index_promodiser', compact('assigned_consignment_store', 'duration', 'inventory_summary', 'total_item_sold', 'total_pending_inventory_audit', 'total_stock_transfer', 'total_stock_adjustments', 'ste_arr', 'branches_with_pending_beginning_inventory', 'due'));
             }
 
             return redirect('/search_results');

--- a/resources/views/consignment/beginning_inv_items.blade.php
+++ b/resources/views/consignment/beginning_inv_items.blade.php
@@ -5,7 +5,7 @@
             <input type="text" class="form-control form-control-sm mt-2 mb-2 ml-0 mr-0" id="item-search" name="search" autocomplete="off" placeholder="Search"/>
         </div>
         <div class="col-4" style="display: flex; justify-content: center; align-items: center;">
-            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#add-item-Modal" style="font-size: 10pt;">
+            <button type="button" class="btn btn-primary btn-sm" id="open-add-items-modal" style="font-size: 10pt;">
                 <i class="fa fa-plus"></i> Add Items
             </button>
               
@@ -218,7 +218,7 @@
 
     <div class="d-none">
         {{-- values to save --}}
-        <input type="text" name="branch" value="{{ $branch }}">
+        <input type="text" id="branch-warehouse" name="branch" value="{{ $branch }}">
         <input type="text" name="inv_name" value="{{ $inv_name }}">
     </div>
 
@@ -237,10 +237,13 @@
                 </div>
                 <div class="modal-body">
                     <div class="container-fluid text-justify" id="input-error-container" style="font-size: 8pt;">
-                        <span><i class="fas fa-info-circle"></i> Please remove item(s) with zero(0) stocks and/or price:</span> <br>
-                        <span>You can remove item(s) by clicking (<i class="fa fa-remove" style='color: red;'></i>)</span>
-                        <div id="inc-item-codes">
-                            <ul></ul>
+                        <span id="null-branch-placeholder" class="d-none"><i class="fas fa-info-circle"></i> Please select a branch<br></span>
+                        <div id="error-in-items-placeholder" class='d-none'>
+                            <span><i class="fas fa-info-circle"></i> Please remove item(s) with zero(0) stocks and/or price:</span> <br>
+                            <span>You can remove item(s) by clicking (<i class="fa fa-remove" style='color: red;'></i>)</span>
+                            <div id="inc-item-codes">
+                                <ul></ul>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -266,13 +269,37 @@
             validate_submit();
         });
 
+        function valid_branch(){
+            if($('#branch-warehouse').val() == '' || $('#branch-warehouse').val() == 'null'){
+                $('#null-store-warning').removeClass('d-none');
+                $('#selected-branch').css('border', '1px solid red');
+            }else{
+                $('#null-store-warning').addClass('d-none');
+                $('#selected-branch').css('border', '1px solid #CED4DA');
+            }
+        }
+        if(branch != 'null' && branch != ''){
+            valid_branch();
+        }
+
+        $("#open-add-items-modal").click(function (){
+            if($('#branch-warehouse').val() == '' || $('#branch-warehouse').val() == 'null'){
+                $('#null-store-warning').removeClass('d-none');
+                $('#selected-branch').css('border', '1px solid red');
+            }else{
+                $('#null-store-warning').addClass('d-none');
+                $('#selected-branch').css('border', '1px solid #CED4DA');
+                $('#add-item-Modal').modal('show');
+            }
+        });
+
         var item_codes = new Array();
         var incorrect_item_codes = new Array();
         $('#submit-btn').click(function (){
             $('.wrong-item-code').remove();
             item_codes = [];
             incorrect_item_codes = [];
-            
+
             $('.validate.stock').each(function(){ // check stocks
                 var item_code = $(this).data('item-code');
                 var stock_value = parseInt($(this).val());
@@ -526,8 +553,6 @@
             add_item('#items-table tbody');
             $('#add-item-Modal').modal('hide')
 
-            $('#item-count').text(parseInt($('#item-count').text()) + 1);
-
             // Reset values
             $('#new-item-code').text('');
             $('#new-description').text('');
@@ -634,6 +659,7 @@
             }
 
             $("#item-selection").empty().trigger('change');
+            $('#item-count').text(parseInt($('#item-count').text()) + 1);
 
             validate_submit();
 		}

--- a/resources/views/consignment/beginning_inv_items.blade.php
+++ b/resources/views/consignment/beginning_inv_items.blade.php
@@ -237,13 +237,10 @@
                 </div>
                 <div class="modal-body">
                     <div class="container-fluid text-justify" id="input-error-container" style="font-size: 8pt;">
-                        <span id="null-branch-placeholder" class="d-none"><i class="fas fa-info-circle"></i> Please select a branch<br></span>
-                        <div id="error-in-items-placeholder" class='d-none'>
-                            <span><i class="fas fa-info-circle"></i> Please remove item(s) with zero(0) stocks and/or price:</span> <br>
-                            <span>You can remove item(s) by clicking (<i class="fa fa-remove" style='color: red;'></i>)</span>
-                            <div id="inc-item-codes">
-                                <ul></ul>
-                            </div>
+                        <span><i class="fas fa-info-circle"></i> Please remove item(s) with zero(0) stocks and/or price:</span> <br>
+                        <span>You can remove item(s) by clicking (<i class="fa fa-remove" style='color: red;'></i>)</span>
+                        <div id="inc-item-codes">
+                            <ul></ul>
                         </div>
                     </div>
                 </div>

--- a/resources/views/consignment/beginning_inv_list.blade.php
+++ b/resources/views/consignment/beginning_inv_list.blade.php
@@ -52,7 +52,7 @@
                                         </td>
                                         <td class="font-responsive p-2 align-middle">
                                             <a href="/beginning_inventory{{ ($store->status == 'For Approval' ? '/' : '_items/').$store->name }}">{{ $store->branch_warehouse }}</a>
-
+                                            <small class="d-block">Created by: {{ $store->owner }}</small>
                                             @if ($store->status == 'Approved')
                                                 <small class="d-block">Approved by: {{ $store->approved_by }}</small>
                                                 <small class="d-block">Date: {{ Carbon\Carbon::parse($store->date_approved)->format('M d, Y - h:i A') }}</small>

--- a/resources/views/consignment/beginning_inventory.blade.php
+++ b/resources/views/consignment/beginning_inventory.blade.php
@@ -81,7 +81,7 @@
             var selected_branch = '{{ $branch ? $branch : "none" }}';
             selected_branch = selected_branch != 'none' ? selected_branch : $('#selected-branch').val();
 
-            if(selected_branch != 'none' && $('#selected-branch').val() != null){
+            if(selected_branch != 'none' || $('#selected-branch').val() != null){
                 get_inv_record(selected_branch);
             }
             

--- a/resources/views/consignment/beginning_inventory.blade.php
+++ b/resources/views/consignment/beginning_inventory.blade.php
@@ -31,6 +31,7 @@
                                             <option value="{{ $store }}">{{ $store }}</option>
                                         @endforeach
                                     </select>
+                                    <span class='font-italic d-none' id='null-store-warning' style="font-size: 9pt; color: red;">* Please select a store first</span>
                                 </div>
                             </div>
                             @endif

--- a/resources/views/consignment/beginning_inventory_list.blade.php
+++ b/resources/views/consignment/beginning_inventory_list.blade.php
@@ -13,7 +13,7 @@
 						<div class="card-header p-2">
                             <div class="d-flex flex-row align-items-center justify-content-between" style="font-size: 9pt;">
                                 <div class="p-0">
-                                    <span class="font-responsive font-weight-bold text-uppercase m-0 p-0">Stock Adjustments List</span>
+                                    <span class="font-responsive font-weight-bold text-uppercase m-0 p-0">Beginning Inventory List</span>
                                 </div>
                                 <div class="p-0">
                                     <a href="/beginning_inventory" class="btn btn-sm btn-primary m-0"><i class="fas fa-plus"></i> Create</a>

--- a/resources/views/consignment/index_promodiser.blade.php
+++ b/resources/views/consignment/index_promodiser.blade.php
@@ -65,9 +65,9 @@
           <a href="/inventory_audit">
             <div class="info-box bg-gradient-info m-0">
               <div class="info-box-content p-1">
-                <span class="info-box-text" style="font-size: 9pt;">Inventory Audit</span>
+                <span class="info-box-text" style="font-size: 9pt;">Inventory Report</span>
                 <span class="info-box-number">{{ number_format($total_pending_inventory_audit) }}</span>
-                <span class="progress-description" style="font-size: 7pt;">{{ $duration }}</span>
+                <span class="progress-description" style="font-size: 7pt;">{{ $due }}</span>
               </div>
             </div>
           </a>
@@ -89,7 +89,7 @@
           <a href="/beginning_inv_list">
             <div class="info-box bg-gradient-secondary m-0">
               <div class="info-box-content p-1">
-                <span class="info-box-text" style="font-size: 9pt;">Stock Adjustment</span>
+                <span class="info-box-text" style="font-size: 9pt;">Beginning Inventory</span>
                 <span class="info-box-number">{{ number_format($total_stock_adjustments) }}</span>
                 <div class="progress">
                   <div class="progress-bar"></div>

--- a/resources/views/consignment/index_promodiser.blade.php
+++ b/resources/views/consignment/index_promodiser.blade.php
@@ -28,7 +28,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      @foreach (array_keys($branches_with_pending_beginning_inventory) as $branch)
+                      @foreach (($branches_with_pending_beginning_inventory) as $branch)
                         <tr>
                           <td>{{ $branch }}</td>
                           <td class="text-center"><a href="/beginning_inventory?branch={{ $branch }}" class="btn btn-primary btn-xs" style="font-size: 9pt"><i class="fa fa-plus"></i> Create</a></td>

--- a/resources/views/consignment/index_promodiser.blade.php
+++ b/resources/views/consignment/index_promodiser.blade.php
@@ -266,6 +266,7 @@
                             </div>
                             <div class="modal-footer">
                               @if ($ste['status'] == 'Delivered' && $ste['delivery_status'] == 0)
+                                <input type="checkbox" name="receive_delivery" class="d-none" checked readonly>
                                 <button type="submit" class="btn btn-primary w-100">Receive</button>
                               @else
                                 <button type="submit" class="btn btn-info w-100">Update Prices</button>

--- a/resources/views/consignment/inventory_audit_form.blade.php
+++ b/resources/views/consignment/inventory_audit_form.blade.php
@@ -16,7 +16,7 @@
                                     <a href="/inventory_audit" class="btn btn-secondary m-0" style="width: 60px;"><i class="fas fa-arrow-left"></i></a>
                                 </div>
                                 <div class="p-1 col-8">
-                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Inventory Audit Form</span>
+                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Inventory Report Form</span>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/consignment/product_sold_form.blade.php
+++ b/resources/views/consignment/product_sold_form.blade.php
@@ -54,6 +54,11 @@
 
                                             $img_count = array_key_exists($row->item_code, $item_images) ? count($item_images[$row->item_code]) : 0;
 
+                                            $max = $consigned_qty;
+                                            if ($qty > 0) {
+                                                $max = $consigned_qty + $qty;
+                                            }
+
                                             if(session()->has('error')) {
                                                 $data = session()->get('old_data');
                                                 $qty = $data['item'][$row->item_code]['qty'];
@@ -81,7 +86,7 @@
                                                                 <button class="btn btn-outline-danger btn-xs qtyminus" style="padding: 0 5px 0 5px;" type="button">-</button>
                                                             </div>
                                                             <div class="custom-a p-0">
-                                                                <input type="number" class="form-control form-control-sm qty item-sold-qty" value="{{ $qty }}" name="item[{{ $row->item_code }}][qty]" style="text-align: center; width: 80px;" data-max="{{ $consigned_qty }}" data-price="{{ $row->price }}">
+                                                                <input type="number" class="form-control form-control-sm qty item-sold-qty" value="{{ $qty }}" name="item[{{ $row->item_code }}][qty]" style="text-align: center; width: 80px;" data-max="{{ $max }}" data-price="{{ $row->price }}">
                                                             </div>
                                                             <div class="input-group-append p-0">
                                                                 <button class="btn btn-outline-success btn-xs qtyplus" style="padding: 0 5px 0 5px;" type="button">+</button>

--- a/resources/views/consignment/promodiser_delivery_report.blade.php
+++ b/resources/views/consignment/promodiser_delivery_report.blade.php
@@ -65,6 +65,9 @@
                                             <small class="d-block"><b>{{ $ste['name'] }}</b> | <b>Delivery Date:</b> {{ $delivery_date }}</small>
                                             @if ($ste['delivery_status'] == 1)
                                                 <small class="d-block"><b>Date Received:</b> {{ Carbon\Carbon::parse($ste['date_received'])->format('M d, Y - h:i a') }}</small>
+                                                @if ($ste['received_by'])
+                                                    <small class="d-block"><b>Received By:</b> {{ $ste['received_by'] }}</small>
+                                                @endif
                                             @endif
                                             <span class="badge badge-{{ $ste['status'] == 'Pending' ? 'warning' : 'success' }}">{{ $ste['status'] }}</span>
                                             @if ($ste['status'] == 'Delivered')

--- a/resources/views/consignment/promodiser_inventory_audit_list.blade.php
+++ b/resources/views/consignment/promodiser_inventory_audit_list.blade.php
@@ -12,7 +12,7 @@
                     <div class="card card-lightblue">
                         @if (count($pending) > 0)
                         <div class="card-header text-center p-2">
-                            <span class="font-weight-bolder d-block text-uppercase" style="font-size: 11pt;">Inventory Audit List</span>
+                            <span class="font-weight-bolder d-block text-uppercase" style="font-size: 11pt;">Inventory Report List</span>
                         </div>
                         <div class="card-body p-1">
                             <div class="p-2">
@@ -46,7 +46,7 @@
                         </div>
                         @endif
                         <div class="card-header text-center p-2 bg-lightblue border-0 rounded-0">
-                            <span class="font-weight-bolder d-block text-uppercase" style="font-size: 11pt;">Inventory Audit History</span>
+                            <span class="font-weight-bolder d-block text-uppercase" style="font-size: 11pt;">Inventory Report History</span>
                         </div>
                         <div class="card-body p-1">
                             <form id="inventory-audit-history-form" method="GET">

--- a/resources/views/consignment/supervisor/tbl_audit_deliveries.blade.php
+++ b/resources/views/consignment/supervisor/tbl_audit_deliveries.blade.php
@@ -8,10 +8,10 @@
 <div class="table-responsive p-0 {{ count($list) > 0 ? 'tbl-custom-height' : '' }}">
     <table class="table table-bordered table-striped table-head-fixed" style="font-size: 9pt;">
         <thead class="border-top bg-navy">
-            <th class="text-center font-responsive p-2 align-middle first" style="width: 55%;">Item Code</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Qty</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Rate</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Amount</th>
+            <th class="text-center font-responsive p-2 align-middle first bg-navy" style="width: 55%;">Item Code</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Qty</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Rate</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Amount</th>
         </thead>
         <tbody>
             @forelse ($list as $d)

--- a/resources/views/consignment/supervisor/tbl_audit_returns.blade.php
+++ b/resources/views/consignment/supervisor/tbl_audit_returns.blade.php
@@ -8,10 +8,10 @@
 <div class="table-responsive p-0 {{ count($list) > 0 ? 'tbl-custom-height' : '' }}">
     <table class="table table-bordered table-striped table-head-fixed" style="font-size: 9pt;">
         <thead class="border-top bg-navy">
-            <th class="text-center font-responsive p-2 align-middle first" style="width: 55%;">Item Code</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Qty</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Rate</th>
-            <th class="text-center font-responsive p-2 align-middle" style="width: 15%;">Amount</th>
+            <th class="text-center font-responsive p-2 align-middle first bg-navy" style="width: 55%;">Item Code</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Qty</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Rate</th>
+            <th class="text-center font-responsive p-2 align-middle bg-navy" style="width: 15%;">Amount</th>
         </thead>
         <tbody>
             @forelse ($list as $d)

--- a/resources/views/consignment/supervisor/view_inventory_audit.blade.php
+++ b/resources/views/consignment/supervisor/view_inventory_audit.blade.php
@@ -12,7 +12,10 @@
                     <div class="row">
                         <div class="col-2">
                             <div style="margin-bottom: -43px;">
-                                <a href="/" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
+                                @php
+                                    $redirecthref = Auth::user()->user_group == 'Director' ? '/consignment_dashboard' : '/';
+                                @endphp
+                                <a href="{{ $redirecthref }}" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
                             </div>
                         </div>
                         <div class="col-8 col-lg-8 p-0">

--- a/resources/views/consignment/supervisor/view_product_sold_list.blade.php
+++ b/resources/views/consignment/supervisor/view_product_sold_list.blade.php
@@ -12,7 +12,10 @@
                     <div class="row">
                         <div class="col-2">
                             <div style="margin-bottom: -43px;">
-                                <a href="/" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
+                                @php
+                                    $redirecthref = Auth::user()->user_group == 'Director' ? '/consignment_dashboard' : '/';
+                                @endphp
+                                <a href="{{ $redirecthref }}" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
                             </div>
                         </div>
                         <div class="col-8 col-lg-8 p-0">

--- a/resources/views/consignment/supervisor/view_promodisers_list.blade.php
+++ b/resources/views/consignment/supervisor/view_promodisers_list.blade.php
@@ -12,7 +12,10 @@
                     <div class="row">
                         <div class="col-2">
                             <div style="margin-bottom: -43px;">
-                                <a href="/" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
+                                @php
+                                    $redirecthref = Auth::user()->user_group == 'Director' ? '/consignment_dashboard' : '/';
+                                @endphp
+                                <a href="{{ $redirecthref }}" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
                             </div>
                         </div>
                         <div class="col-10 col-lg-8 p-0">

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -12,7 +12,10 @@
                     <div class="row">
                         <div class="col-2">
                             <div style="margin-bottom: -43px;">
-                                <a href="/" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
+                                @php
+                                    $redirecthref = Auth::user()->user_group == 'Director' ? '/consignment_dashboard' : '/';
+                                @endphp
+                                <a href="{{ $redirecthref }}" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
                             </div>
                         </div>
                         <div class="col-8 col-lg-8 p-0">

--- a/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
+++ b/resources/views/consignment/supervisor/view_stock_adjustments.blade.php
@@ -970,7 +970,7 @@
                                                         '<picture>' +
                                                             '<source id="mobile-' + item_code + '-webp-image-src" srcset="' + webp + '" type="image/webp" class="d-block w-100" style="width: 100% !important;">' +
                                                             '<source id="mobile-' + item_code + '-orig-image-src" srcset="' + img + '" type="image/jpeg" class="d-block w-100" style="width: 100% !important;">' +
-                                                            '<img class="d-block w-100" id="mobile-' + item_code + '-image" src="' + img + '" alt="{{ Illuminate\Support\Str::slug(explode('.', $img)[0], '-') }}">' +
+                                                            '<img class="d-block w-100" id="mobile-' + item_code + '-image" src="' + img + '" alt="' + item_code + '">' +
                                                         '</picture>' +
                                                     '</div>' +
                                                     '<span class="d-none" id="mobile-' + item_code + '-image-data">0</span>' +

--- a/resources/views/consignment/view_damaged_items_list.blade.php
+++ b/resources/views/consignment/view_damaged_items_list.blade.php
@@ -12,7 +12,10 @@
                     <div class="row">
                         <div class="col-3">
                             <div style="margin-bottom: -43px;">
-                                <a href="/" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
+                                @php
+                                    $redirecthref = Auth::user()->user_group == 'Director' ? '/consignment_dashboard' : '/';
+                                @endphp
+                                <a href="{{ $redirecthref }}" class="btn btn-secondary" style="width: 80px;"><i class="fas fa-arrow-left"></i></a>
                             </div>
                         </div>
                         <div class="col-7 col-lg-6 p-0">

--- a/resources/views/consignment/view_inventory_audit_items.blade.php
+++ b/resources/views/consignment/view_inventory_audit_items.blade.php
@@ -16,7 +16,7 @@
                                     <a href="/inventory_audit" class="btn btn-secondary m-0" style="width: 60px;"><i class="fas fa-arrow-left"></i></a>
                                 </div>
                                 <div class="p-1 col-8">
-                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Inventory Audit Item(s)</span>
+                                    <span class="font-weight-bolder d-block font-responsive text-uppercase">Inventory Report Item(s)</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
# Release notes - AthenaERP Inventory - Version Version 5.5.2

### Bug

[AI-425](https://fumacoinc.atlassian.net/browse/AI-425) In Promodiser Dashboard, cannot receive delivered items

[AI-424](https://fumacoinc.atlassian.net/browse/AI-424) In promodiser dashboard, reminder modal for store without beginning inventory keeps showing after creating beginning inventory

[AI-423](https://fumacoinc.atlassian.net/browse/AI-423) In Damaged Items, returning an item does not deduct damaged qty from the consigned qty

[AI-422](https://fumacoinc.atlassian.net/browse/AI-422) In item to receive list, draft stock entries is in the list

[AI-417](https://fumacoinc.atlassian.net/browse/AI-417) In Beginning Inventory Entry, can submit form without consignment store

[AI-416](https://fumacoinc.atlassian.net/browse/AI-416) In Inventory Audit, Issue in pending inventory audit date duration

[AI-415](https://fumacoinc.atlassian.net/browse/AI-415) In Product Sold Entry, Cancelling a beginning inventory also removes sold qty of items that are not included in the beginning inventory record

[AI-414](https://fumacoinc.atlassian.net/browse/AI-414) In Product Sold Entry, Updating product sold cannot increase qty sold

[AI-412](https://fumacoinc.atlassian.net/browse/AI-412) In Beginning Inventory, Items are not shown for 'For Approval' beginning inventory record

[AI-410](https://fumacoinc.atlassian.net/browse/AI-410) Back button redirects to "Plant Transactions" tab for Director user group

[AI-409](https://fumacoinc.atlassian.net/browse/AI-409) In view stock adjustments list, error while filtering specific store

### Task

[AI-420](https://fumacoinc.atlassian.net/browse/AI-420) In Beginning Inventory List, add the name of the promodiser


Added Doctype for Stock Entry Detail
- Consignment Received By